### PR TITLE
Polish home listings and editorial content

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,8 @@ npm install
 npm run dev
 ```
 
-- `npm run dev` recompila assets y levanta `zola serve`.
+- `npm run dev` recompila assets y levanta `zola serve` sin drafts.
+- `npm run dev:drafts` hace lo mismo pero incluye borradores.
 - `npm run build` genera `public/`.
 - `npm run preview` levanta una preview local con Wrangler sobre el build.
 

--- a/content/blog/a-traves-de-tus-ojos.md
+++ b/content/blog/a-traves-de-tus-ojos.md
@@ -2,24 +2,26 @@
 title = "A través de tus ojos"
 slug = "a-traves-de-tus-ojos"
 date = 2025-06-23 18:08:57
-description = "A través de tus ojos - La Portuaria Yo puedo ver el mundo y comprender el paso de los días. Entendernos sin palabras, abrazando nuestro cómplice silencio. Tu risa…"
-draft = true
+description = "A través de tus ojos. Una canción de La Portuaria."
+draft = false
 template = "article.html"
 authors = [
-    "Martín Gaitán",
+    "La Portuaria",
 ]
 categories = [
     "Blog",
 ]
 tags = [
     "El resto",
+    "Música",
+    "Canción",
 ]
 
 [extra]
 legacy_id = 78
 section_slug = "blog"
 section_title = "Blog"
-summary = "A través de tus ojos - La Portuaria Yo puedo ver el mundo y comprender el paso de los días. Entendernos sin palabras, abrazando nuestro cómplice silencio. Tu risa vuelve el tiempo mas liviano y vulnerable, y pierden…"
+summary = "A través de tus ojos. Una canción de La Portuaria sobre el tiempo compartido, la intimidad y la mirada amorosa."
 visits = 0
 popularite = 0.0
 hero_image = ""
@@ -30,41 +32,47 @@ surtitle = ""
 subtitle = ""
 deck = ""
 author_links = [
-    { name = "Martín Gaitán", path = "/autores/martin/" },
+    { name = "La Portuaria", path = "" },
 ]
 tag_links = [
     { name = "El resto", path = "/etiquetas/el-resto/" },
+    { name = "Música", path = "/etiquetas/musica/" },
+    { name = "Canción", path = "/etiquetas/cancion/" },
 ]
 comments = []
 +++
 
-<span style="font-weight: bold">A través de tus ojos - La Portuaria</span>
+<div class="poetry">Yo puedo ver el mundo<br>
+y comprender el paso de los días.<br>
+Entendernos sin palabras,<br>
+abrazando nuestro cómplice silencio.<br>
+<br>
+Tu risa vuelve el tiempo más liviano y vulnerable,<br>
+y pierden peso las cosas del mundo.<br>
+Son mejores a través de tu mirada.<br>
+<br>
+Donde corre el agua,<br>
+donde sopla el viento,<br>
+puedo ver a través de tus ojos.<br>
+<br>
+Ya nada se detiene,<br>
+las cosas son distintas.<br>
+Atravesando el muro de viejas armaduras<br>
+las fórmulas no tienen más sentido.<br>
+<br>
+Tus ojos me despiertan si me quedo dormido.<br>
+Yo sueño tu futuro y lo vivo cada día,<br>
+y en cada cosa que hago vos siempre estás conmigo.<br>
+<br>
+Donde corre el agua,<br>
+donde sopla el viento,<br>
+puedo ver a través de tus ojos.<br>
+Donde corre el agua,<br>
+donde duerme el tiempo,<br>
+puedo ver a través de tus ojos.</div>
 
-Yo puedo ver el mundo
-y comprender el paso de los días.
-Entendernos sin palabras,
-abrazando nuestro cómplice silencio.
+{% postscript() %}
+Autores: Frenkel / Schachtel / Belmonte.
 
-Tu risa vuelve el tiempo mas liviano y vulnerable,
-y pierden peso las cosas del mundo.
-Son mejores a traves de tu mirada.
-
-Donde corre el agua,
-donde sopla el viento
-puedo ver a traves de tus ojos.
-
-Ya nada se detiene,
-las cosas son distintas.
-Atravesando el muro de viejas armaduras
-las formulas no tienen mas sentido.
-
-Tus ojos me despierten si me quedo dormido.
-Yo sueño tu futuro y lo vivo cada dia,
-y en cada cosa que hago vos siempre estas conmigo
-
-Donde corre el agua,
-donde sopla el viento,
-puedo ver a través de tus ojos.
-Donde corre el agua,
-donde duerme el tiempo,
-puedo ver a través de tus ojos
+Disco: Río (2005).
+{% end %}

--- a/content/blog/ascenso.md
+++ b/content/blog/ascenso.md
@@ -12,8 +12,9 @@ categories = [
     "Blog",
 ]
 tags = [
-    "Amor",
-    "Memoria",
+    "Poesía",
+    "Cine",
+    "Personas",
 ]
 
 [extra]
@@ -29,26 +30,24 @@ comment_count = 0
 legacy_url = "/blog/ascenso/"
 surtitle = ""
 subtitle = ""
-deck = ""
+deck = "*A la memoria de Daniel Salzano*"
 author_links = [
     { name = "Martín Gaitán", path = "/autores/martin/" },
 ]
 tag_links = [
-    { name = "Amor", path = "/etiquetas/amor/" },
-    { name = "Memoria", path = "/etiquetas/memoria/" },
+    { name = "Poesía", path = "/etiquetas/poesia/" },
+    { name = "Cine", path = "/etiquetas/cine/" },
+    { name = "Personas", path = "/etiquetas/personas/" },
 ]
 comments = []
 +++
 
-<div style="float:right"><em>A la memoria de Daniel Salzano</em></div><p></p>
-<p></p>
-
-Adiós poeta / gracias por enseñarme a escarbar el cine /tu cine / sus asientos / tus encondrijos
-
-Adiós poeta / gracias por las barritas / pausitas de adoquín jesuita / donde tus ojos / che culiado / veían como halcón / o mejor como cóndor
-
-Adiós poeta / gracias por la ternura / y el amor a esta ciudad / la tenías entre ceja y ceja / le inventabas sonidos / nubes / jugadores
-
-Adiós poeta / gracias por tu sapiencia / por saber que Chaplín la pisaba como Riquelme / calzaba cuarentinueve 
-
-Y gracias por las columnas / tu rutina de obrero / de tinta / hacer columnas que sostienen la luna / y la sostendrán / vos sí ascendiste / poeta
+<div class="poetry">Adiós poeta / gracias por enseñarme a escarbar el cine / tu cine / sus asientos / tus encondrijos<br>
+<br>
+Adiós poeta / gracias por las barritas / pausitas de adoquín jesuita / donde tus ojos / che culiado / veían como halcón / o mejor como cóndor<br>
+<br>
+Adiós poeta / gracias por la ternura / y el amor a esta ciudad / la tenías entre ceja y ceja / le inventabas sonidos / nubes / jugadores<br>
+<br>
+Adiós poeta / gracias por tu sapiencia / por saber que Chaplín la pisaba como Riquelme / calzaba cuarentinueve<br>
+<br>
+Y gracias por las columnas / tu rutina de obrero / de tinta / hacer columnas que sostienen la luna / y la sostendrán / vos sí ascendiste / poeta</div>

--- a/content/blog/el-termo.md
+++ b/content/blog/el-termo.md
@@ -82,7 +82,7 @@ Pero algo sucede: una señora desde otro pasillo me ve y luego fija la mirada en
 
 Apuro el paso. Fui muy burdo, pienso. Llegué, lo dejé y me quedé mirándolo como un terrorista newbie que duda de su acto en el último instante. Podría haber simulado un minúsculo rezo y luego olvidarme, oh que descuidado, mi termo (por pocos minutos, pero mio al fin) en el piso. Pero ya estoy jugado para nuevos lamentos, debo escapar, es urgente. Los escalones están deliberadamente calculados para ser molestos en una escapatoria: son bajos y anchos, no se pueden saltar de dos en dos pero tampoco alcanza para dar otro paso sobre el mismo escalón y lograr así un humilde trotecito. Bajar rápido implica una especie de cojera obligada (un pie baja, el otro se arrastra) que me sindica desde la altitud omnisciente del pórtico como el sospechoso de siempre. Imposible pasar desapercibido, llevo todas las *red flags* de que algo hice. Y ahí voy, sin termo, sin suerte, con la certeza de ser perseguido. {En moi, la morte se réveille] (En mí la muerte despierta). El vesre frío, implacable: morte, termo.
 
-— {Where did you go, Martin, did you go back to pray?]
+— *Where did you go, Martin, did you go back to pray?*
 — *More or less, yeah. You know, everybody must to expiate their sins.*
 
 Pero ahora vayámonos, rumana, que esto puede explotar en cualquier momento.

--- a/content/blog/fideo.md
+++ b/content/blog/fideo.md
@@ -14,6 +14,8 @@ categories = [
 tags = [
     "La pelota no se mancha",
     "Memoria",
+    "Personas",
+    "Deporte",
 ]
 
 [extra]
@@ -36,6 +38,8 @@ author_links = [
 tag_links = [
     { name = "La pelota no se mancha", path = "/etiquetas/la-pelota-no-se-mancha/" },
     { name = "Memoria", path = "/etiquetas/memoria/" },
+    { name = "Personas", path = "/etiquetas/personas/" },
+    { name = "Deporte", path = "/etiquetas/deporte/" },
 ]
 comments = []
 +++

--- a/content/videos/el-umbral.md
+++ b/content/videos/el-umbral.md
@@ -38,7 +38,7 @@ tag_links = [
 comments = []
 +++
 
-{{ video_embed(provider="youtube", id="etY9ISesBRQ") }}
+{{ video_embed(provider="youtube", id="39DnBGPApZc") }}
 
 ### El umbral
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "build:assets": "vite build",
     "build": "npm run build:assets && zola build",
     "dev:assets": "vite build --watch --mode development",
-    "dev": "npm run build:assets && zola serve --drafts --open",
+    "dev": "npm run build:assets && zola serve --open",
+    "dev:drafts": "npm run build:assets && zola serve --drafts --open",
     "new:article": "uv run scripts/new_article.py",
     "preview": "npm run build && npx wrangler pages dev public --compatibility-date=2026-04-24",
     "deploy": "npm run build && npx wrangler pages deploy public --project-name textosypretextos"

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -460,6 +460,21 @@
     @apply md:grid-cols-1;
   }
 
+  .home-listing-card {
+    @apply grid gap-5 py-6 md:grid-cols-[190px_minmax(0,1fr)];
+  }
+
+  .home-listing-card.no-media {
+    @apply md:grid-cols-1;
+  }
+
+  .home-listing-summary {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 4;
+    overflow: hidden;
+  }
+
   .taxonomy-grid {
     @apply grid gap-5 border-t border-black pt-8 sm:grid-cols-2 xl:grid-cols-3;
   }
@@ -574,6 +589,10 @@
 
   .home-blog-rest .feed-item {
     @apply border-b border-neutral-300 py-6 last:border-b-0;
+  }
+
+  .home-blog-rest .home-listing-card {
+    @apply border-b border-neutral-300 last:border-b-0;
   }
 
   .sidebar-block {

--- a/templates/index.html
+++ b/templates/index.html
@@ -27,7 +27,7 @@
             <div class="home-blog-rest">
               {% for page in blog_pages %}
                 {% if not loop.first %}
-                  {{ macros::story_card(page=page, variant="compact") }}
+                  {{ macros::story_card(page=page, variant="home-list") }}
                 {% endif %}
               {% endfor %}
             </div>

--- a/templates/partials/macros.html
+++ b/templates/partials/macros.html
@@ -2,15 +2,16 @@
   {% set is_feature = variant == "feature" %}
   {% set is_compact = variant == "compact" %}
   {% set is_list = variant == "list" %}
+  {% set is_home_list = variant == "home-list" %}
   {% set use_subcat = page.extra.section_slug in ["blog", "de-otros"] and page.extra.tag_links and page.extra.tag_links | length > 0 %}
   {% if use_subcat %}
     {% set kicker_text = page.extra.tag_links[0].name %}
   {% else %}
     {% set kicker_text = page.extra.section_title %}
   {% endif %}
-  <article class="{% if is_list %}listing-card{% elif is_compact %}feed-item{% else %}grid gap-5{% endif %}{% if not page.extra.hero_image %} no-media{% endif %}">
+  <article class="{% if is_list %}listing-card{% elif is_home_list %}home-listing-card{% elif is_compact %}feed-item{% else %}grid gap-5{% endif %}{% if not page.extra.hero_image %} no-media{% endif %}">
     {% if page.extra.hero_image %}
-      <a href="{{ page.permalink }}" class="media-frame {% if page.extra.section_slug == 'videos' %}video{% endif %} reveal {% if is_feature %}aspect-[16/10]{% elif is_list %}aspect-[4/3]{% else %}aspect-[16/9]{% endif %}">
+      <a href="{{ page.permalink }}" class="media-frame {% if page.extra.section_slug == 'videos' %}video{% endif %} reveal {% if is_feature %}aspect-[16/10]{% elif is_list or is_home_list %}aspect-[4/3]{% else %}aspect-[16/9]{% endif %}">
         <img src="{{ page.extra.hero_image }}" alt="{{ page.extra.hero_alt | default(value=page.title) }}">
       </a>
     {% elif page.extra.section_slug == "videos" %}
@@ -27,7 +28,7 @@
         <p class="mt-2 text-base text-neutral-600">{{ page.extra.subtitle }}</p>
       {% endif %}
       {% if page.extra.summary %}
-        <p class="story-deck {% if is_compact %}text-base leading-7{% endif %}">
+        <p class="story-deck {% if is_compact or is_home_list %}text-base leading-7{% endif %}{% if is_home_list %} home-listing-summary{% endif %}">
           {{ page.extra.summary }}
         </p>
       {% endif %}
@@ -48,7 +49,7 @@
           <span>{{ page.extra.comment_count }} comentarios</span>
         {% endif %}
       </div>
-      {% if page.extra.tag_links and not is_compact %}
+      {% if page.extra.tag_links and not is_compact and not is_home_list %}
         {% if use_subcat %}{% set tag_start = 1 %}{% else %}{% set tag_start = 0 %}{% endif %}
         {% if page.extra.tag_links | length > tag_start %}
           <div class="mt-4 flex flex-wrap gap-2">

--- a/templates/section.html
+++ b/templates/section.html
@@ -7,9 +7,8 @@
 {% block content %}
   <main class="pt-8">
     <section class="editorial-rule">
-      <span class="section-ribbon">{{ section.title }}</span>
       <div class="mt-5 max-w-[52rem]">
-        <h2 class="story-title">{{ section.title }}</h2>
+        <h1 class="story-title">{{ section.title }}</h1>
         {% if section.content %}
           <div class="story-deck story-content">{{ section.content | safe }}</div>
         {% elif section.extra.summary %}


### PR DESCRIPTION
## Qué incluye
- cambia `npm run dev` para reflejar producción y deja `npm run dev:drafts` como opción explícita
- estabiliza el listado del blog en home con teaser lateral y thumbnail para entradas con imagen
- simplifica el encabezado de páginas de sección para evitar repetición visual
- corrige `el-termo`, `ascenso`, `a-traves-de-tus-ojos`, `fideo` y `el-umbral`

## Issues
Refs #12
Refs #14
Refs #15
Refs #17
Refs #18
Refs #19
Refs #20
Refs #21

## Verificación
- `npm run build`
