### PR TITLE
Hide azul image behind a modal reveal

### DIFF
--- a/content/blog/azul-mi-amor-de-invierno.md
+++ b/content/blog/azul-mi-amor-de-invierno.md
@@ -186,10 +186,16 @@ Extraño mis sábanas calientes, impregnadas de tu fulgor. Extraño despertarme 
 
 El invierno se fue y vos con él. No sé dónde, Azul, no sé dónde y eso me angustia. Me dijo alguien, hace poco, que a la noche, entre sueños, te llamo. Entonces tuve que contarle, le conté de vos, de cómo apareciste en mi vida y cómo te fuiste. Le conté que cada noche te busco, que a veces creo que es un chiste, que estás escondida en el placard o bajo la cama. Pero no, te has ido. Quizas en el próximo invierno, me vengas a visitar.
 
-En dónde sea que estes, quería que tuvieras esta carta. Algo mío, más allá del olor de mi piel que hiciste tuyo. A mí me queda este recuerdo hermoso, <a href="/IMG/jpg/Azul.jpg" class="thickbox" title="Azul, mi amor de invierno">y esta foto que te saqué una tarde, mientras dormías</a>.
+En dónde sea que estes, quería que tuvieras esta carta. Algo mío, más allá del olor de mi piel que hiciste tuyo. A mí me queda este recuerdo hermoso, <a href="/media/jpg/Azul.jpg" data-image-modal-trigger="azul" aria-controls="image-modal-azul">y esta foto que te saqué una tarde, mientras dormías</a>.
 
-### Galería
-
-{{ media_image(src="/media/jpg/Azul.jpg", alt="", caption="", align="center") }}
+<div class="image-modal" id="image-modal-azul" data-image-modal hidden aria-hidden="true">
+  <div class="image-modal-dialog" role="dialog" aria-modal="true" aria-labelledby="image-modal-azul-title">
+    <button type="button" class="image-modal-close" data-image-modal-close aria-label="Cerrar imagen">Cerrar</button>
+    <figure class="image-modal-figure">
+      <img src="/media/jpg/Azul.jpg" alt="Azul, mi amor de invierno" loading="lazy">
+      <figcaption id="image-modal-azul-title" class="sr-only">Azul, mi amor de invierno</figcaption>
+    </figure>
+  </div>
+</div>
 
 <span id="comments"></span>

--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -26,6 +26,59 @@ document.querySelectorAll("[data-comment-focus]").forEach((link) => {
   });
 });
 
+// ── Image modals ──────────────────────────────────────────────────────────────
+
+let activeImageModal = null;
+let activeImageTrigger = null;
+
+function closeImageModal(modal) {
+  if (!modal) return;
+  modal.hidden = true;
+  modal.setAttribute("aria-hidden", "true");
+  body.classList.remove("has-modal-open");
+  activeImageModal = null;
+  activeImageTrigger?.focus();
+  activeImageTrigger = null;
+}
+
+function openImageModal(modal, trigger) {
+  if (!modal) return;
+  activeImageModal = modal;
+  activeImageTrigger = trigger || null;
+  modal.hidden = false;
+  modal.setAttribute("aria-hidden", "false");
+  body.classList.add("has-modal-open");
+  modal.querySelector("[data-image-modal-close]")?.focus();
+}
+
+document.querySelectorAll("[data-image-modal-trigger]").forEach((trigger) => {
+  trigger.addEventListener("click", (event) => {
+    const modalId = trigger.getAttribute("data-image-modal-trigger");
+    const modal = modalId ? document.getElementById(`image-modal-${modalId}`) : null;
+    if (!modal) return;
+    event.preventDefault();
+    openImageModal(modal, trigger);
+  });
+});
+
+document.querySelectorAll("[data-image-modal]").forEach((modal) => {
+  modal.addEventListener("click", (event) => {
+    if (event.target === modal) {
+      closeImageModal(modal);
+    }
+  });
+
+  modal.querySelectorAll("[data-image-modal-close]").forEach((button) => {
+    button.addEventListener("click", () => closeImageModal(modal));
+  });
+});
+
+document.addEventListener("keydown", (event) => {
+  if (event.key === "Escape" && activeImageModal) {
+    closeImageModal(activeImageModal);
+  }
+});
+
 // ── Dynamic comments (D1-backed) ─────────────────────────────────────────────
 
 const escapeHtml = (s) =>

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -36,6 +36,10 @@
     background-size: 100% 8px, 8px 100%, auto;
   }
 
+  body.has-modal-open {
+    overflow: hidden;
+  }
+
   body::before {
     content: "";
     position: fixed;
@@ -358,6 +362,34 @@
 
   .article-comment-cta {
     @apply mt-10;
+  }
+
+  .image-modal {
+    position: fixed;
+    inset: 0;
+    z-index: 100;
+    display: grid;
+    place-items: center;
+    padding: 1.5rem;
+    background: rgba(0, 0, 0, 0.88);
+  }
+
+  .image-modal-dialog {
+    @apply relative w-full max-w-[960px];
+  }
+
+  .image-modal-close {
+    font-family: var(--font-ui);
+    @apply absolute right-0 top-0 z-10 border-2 border-white bg-black px-4 py-2 text-[11px] uppercase tracking-[0.22em] text-white transition-colors hover:bg-white hover:text-black;
+    transform: translateY(calc(-100% - 0.75rem));
+  }
+
+  .image-modal-figure {
+    @apply m-0 border border-white bg-black;
+  }
+
+  .image-modal-figure img {
+    @apply block h-auto max-h-[82vh] w-full object-contain;
   }
 
   .article-nav {


### PR DESCRIPTION
## Qué incluye
- saca la galería visible de `azul-mi-amor-de-invierno`
- deja la imagen accesible sólo desde el enlace narrativo
- agrega un modal reutilizable con cierre por botón, click afuera y `Esc`

## Issue
Refs #30

## Verificación
- `npm run build`
- la página generada ya no contiene la galería visible y sí contiene el modal oculto
