### PR TITLE
Links de editar/reportar en cada artículo

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -18,3 +18,5 @@ render_emoji = false
 [extra]
 site_owner = "Martín Gaitán"
 site_description = "Un cuaderno abierto de lecturas, canciones y hallazgos."
+github_repo = "mgaitan/textosypretextos"
+github_branch = "main"

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -364,6 +364,19 @@
     @apply mt-10;
   }
 
+  .article-contribute {
+    font-family: var(--font-ui);
+    @apply mt-6 flex flex-wrap items-center gap-2 text-[10px] uppercase tracking-[0.22em] text-neutral-500;
+  }
+
+  .article-contribute-link {
+    @apply text-neutral-600 underline decoration-neutral-300 underline-offset-4 hover:text-black hover:decoration-black;
+  }
+
+  .article-contribute-sep {
+    @apply text-neutral-400;
+  }
+
   .image-modal {
     position: fixed;
     inset: 0;

--- a/templates/article.html
+++ b/templates/article.html
@@ -67,6 +67,23 @@
       <a href="#comment-form" class="more-link" data-comment-focus>Dejá un comentario</a>
     </div>
 
+    {% if config.extra.github_repo and page.relative_path %}
+      {% set edit_url = "https://github.com/" ~ config.extra.github_repo ~ "/edit/" ~ config.extra.github_branch ~ "/content/" ~ page.relative_path %}
+      {% set issue_title = "Problema en: " ~ page.title | urlencode %}
+      {% set issue_body_raw = "URL: " ~ page.permalink ~ "
+Fuente: content/" ~ page.relative_path ~ "
+
+Descripción:
+" %}
+      {% set issue_body = issue_body_raw | urlencode %}
+      {% set issue_url = "https://github.com/" ~ config.extra.github_repo ~ "/issues/new?title=" ~ issue_title ~ "&body=" ~ issue_body %}
+      <div class="article-contribute reveal">
+        <a href="{{ edit_url }}" class="article-contribute-link" rel="noopener" target="_blank">Editar en GitHub</a>
+        <span class="article-contribute-sep" aria-hidden="true">·</span>
+        <a href="{{ issue_url }}" class="article-contribute-link" rel="noopener" target="_blank">Reportar un problema</a>
+      </div>
+    {% endif %}
+
     {% if page.lower or page.higher %}
       <nav class="article-nav reveal" aria-label="Navegación entre artículos">
         <div class="article-nav-prev">


### PR DESCRIPTION
## Qué incluye

- Bajo el CTA de comentarios, cada artículo muestra dos links discretos:
  - **Editar en GitHub** → abre el editor web sobre el archivo fuente.
  - **Reportar un problema** → issue precargado con título, URL y path del fuente.
- Repo y branch configurables vía \`[extra].github_repo\` / \`github_branch\` en \`config.toml\`.

## Issue

Closes #34

## Verificación

- \`npm run build\` ok.
- Verificado en \`/blog/\`, \`/fotos/\`, \`/de-otros/\`: ambos links presentes y bien formados.