### PR TITLE
Página aleatoria + link en la nav

### DIFF
--- a/content/random.md
+++ b/content/random.md
@@ -1,0 +1,7 @@
++++
+title = "Aleatorio"
+slug = "random"
+date = 2026-04-25 00:00:00
+template = "random.html"
+in_search_index = false
++++

--- a/templates/base.html
+++ b/templates/base.html
@@ -43,6 +43,7 @@
             <a class="nav-link" href="/fotos/">Fotos</a>
             <a class="nav-link" href="/de-otros/">De otros</a>
             <a class="nav-link" href="/videos/">Videos</a>
+            <a class="nav-link" href="/random/" rel="nofollow" title="Llevame a un texto al azar">Aleatorio</a>
           </div>
           <button class="nav-toggle" type="button" aria-expanded="false" data-nav-toggle>
             <span class="sr-only">Abrir navegación</span>
@@ -56,6 +57,7 @@
             <a class="nav-link" href="/fotos/">Fotos</a>
             <a class="nav-link" href="/de-otros/">De otros</a>
             <a class="nav-link" href="/videos/">Videos</a>
+            <a class="nav-link" href="/random/" rel="nofollow">Aleatorio</a>
             <a class="nav-link" href="/autores/">Autores</a>
             <a class="nav-link" href="/etiquetas/">Etiquetas</a>
           </div>

--- a/templates/random.html
+++ b/templates/random.html
@@ -1,0 +1,58 @@
+{% extends "base.html" %}
+
+{% block title %}Aleatorio · {{ config.title }}{% endblock title %}
+{% block meta_description %}Llevame a cualquier texto del sitio al azar.{% endblock meta_description %}
+
+{% block content %}
+  {% set blog = get_section(path="blog/_index.md") %}
+  {% set fotos = get_section(path="fotos/_index.md") %}
+  {% set deotros = get_section(path="de-otros/_index.md") %}
+  {% set videos = get_section(path="videos/_index.md") %}
+  {% set personal = get_section(path="personal/_index.md") %}
+  {% set urls = blog.pages | concat(with=fotos.pages) | concat(with=deotros.pages) | concat(with=videos.pages) | concat(with=personal.pages) | map(attribute="permalink") %}
+
+  <main class="pt-8 mx-auto max-w-[980px]" data-random-page>
+    <section class="editorial-rule">
+      <span class="section-ribbon">Aleatorio</span>
+      <div class="mt-5">
+        <h1 class="story-title">Llevame a cualquier lado</h1>
+        <p class="story-deck">Te redirigimos a un texto al azar del sitio. Si tenés JavaScript apagado, elegí desde el listado.</p>
+        <p class="meta-row" id="random-status" role="status">Eligiendo…</p>
+        <noscript>
+          <p class="mt-6 text-sm text-neutral-700">Necesitás JavaScript habilitado para el redireccionamiento automático. Mientras tanto, podés navegar las secciones desde el menú.</p>
+        </noscript>
+      </div>
+    </section>
+  </main>
+
+  <script id="random-urls" type="application/json">{{ urls | json_encode | safe }}</script>
+  <script>
+    (function () {
+      var node = document.getElementById("random-urls");
+      if (!node) return;
+      var urls;
+      try {
+        urls = JSON.parse(node.textContent || "[]");
+      } catch (e) {
+        urls = [];
+      }
+      if (!urls.length) {
+        var status = document.getElementById("random-status");
+        if (status) status.textContent = "No hay contenido para sortear.";
+        return;
+      }
+      var here = window.location.pathname.replace(/\/$/, "");
+      var pick;
+      for (var i = 0; i < 8; i++) {
+        pick = urls[Math.floor(Math.random() * urls.length)];
+        try {
+          var path = new URL(pick).pathname.replace(/\/$/, "");
+          if (path !== here) break;
+        } catch (e) {
+          break;
+        }
+      }
+      window.location.replace(pick);
+    })();
+  </script>
+{% endblock content %}


### PR DESCRIPTION
## Qué incluye

- Nueva ruta `/random/`: agrega `content/random.md` con `template = "random.html"`.
- Template serializa los permalinks de `blog`, `fotos`, `de-otros`, `videos` y `personal` en un `<script type=application/json>` y un script inline elige uno al azar y hace `window.location.replace`.
- Evita la URL actual (reintenta hasta 8 veces) y muestra un fallback `<noscript>`.
- Link "Aleatorio" en la nav principal y en el panel mobile, con `rel="nofollow"` para no consumir crawl budget.

## Issue

Closes #32

## Verificación

- `zola build` ok (459 pages).
- `curl /random/` devuelve 200 con el JSON poblado y el script inline.
- Refrescar `/random/` lleva a una página distinta cada vez.