### PR TITLE
fix: ocultar kicker duplicado en tarjetas compactas del sidebar

### DIFF
--- a/templates/partials/macros.html
+++ b/templates/partials/macros.html
@@ -20,7 +20,7 @@
       </a>
     {% endif %}
     <div class="reveal">
-      <p class="story-kicker">{{ kicker_text }}</p>
+      {% if not is_compact %}<p class="story-kicker">{{ kicker_text }}</p>{% endif %}
       <h2 class="{% if is_feature %}story-title{% elif is_compact %}story-title-xs{% elif is_list %}story-title-sm{% else %}story-title-sm{% endif %}">
         <a href="{{ page.permalink }}">{{ page.title }}</a>
       </h2>


### PR DESCRIPTION
## Problema

En la home, las secciones Foto, Video y De otros ya muestran su etiqueta de sección con `section-ribbon`. El macro `story_card` también renderizaba un `story-kicker` con el mismo texto dentro de la tarjeta, resultando en duplicación.

Fixes #65, #66

## Solución

En `macros.html`, el `story-kicker` ya no se renderiza cuando se usa la variante `compact` (usada en el sidebar de la home).

## Test plan

- [ ] Verificar que las tarjetas de Foto, Video y De otros en el sidebar de la home no muestren el kicker duplicado
- [ ] Verificar que el kicker sí aparece en variantes `feature`, `list` y `home-list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)