### PR TITLE
fix: modal de imagen cubre el viewport completo

### DIFF
--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -27,6 +27,12 @@ document.querySelectorAll("[data-comment-focus]").forEach((link) => {
 });
 
 // ── Image modals ──────────────────────────────────────────────────────────────
+// Modals must live directly on <body> so that `position:fixed` is not trapped
+// inside a transformed ancestor (.reveal uses transform, creating a new
+// stacking context that breaks fixed positioning).
+document.querySelectorAll("[data-image-modal]").forEach((modal) => {
+  document.body.appendChild(modal);
+});
 
 let activeImageModal = null;
 let activeImageTrigger = null;


### PR DESCRIPTION
## Problema

El modal de imagen (usado en "Azul, mi amor de invierno") solo se centraba sobre el div del artículo, no sobre toda la página.

Fixes #70

## Causa raíz

La clase `.reveal` aplicada al `<article>` usa `transform: translateY(...)`, lo que crea un nuevo stacking context. Los elementos con `position: fixed` dentro de un ancestro transformado se posicionan relativo a ese ancestro, no al viewport.

## Solución

En `site.js`, antes de bindear los eventos de los modales, se mueven todos los elementos `[data-image-modal]` directamente al `<body>` con `appendChild`. Así `position: fixed` funciona correctamente.

## Test plan

- [ ] Ir a `/blog/azul-mi-amor-de-invierno/`
- [ ] Hacer click en el link "y esta foto que te saqué una tarde"
- [ ] Verificar que el overlay cubre toda la pantalla (no solo el artículo)
- [ ] Verificar que se puede cerrar con el botón Cerrar y con Escape

🤖 Generated with [Claude Code](https://claude.com/claude-code)