### PR TITLE
fix: foto portada dinámica y borde superior en sidebar (#88 #89)

### DIFF
--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -646,7 +646,7 @@
   }
 
   .home-sidebar .media-frame {
-    @apply border-2;
+    @apply border-t-2 border-black;
   }
 
   .comment-stack {

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,7 +5,8 @@
 
 {% block content %}
   {% set blog = get_section(path="blog/_index.md") %}
-  {% set featured_photo = get_page(path=section.extra.featured_photo_path) %}
+  {% set fotos_section = get_section(path="fotos/_index.md") %}
+  {% set featured_photo = fotos_section.pages | first %}
   {% set latest_video = get_page(path=section.extra.latest_video_path) %}
   {% set latest_other = get_page(path=section.extra.latest_other_path) %}
   {% set blog_pages = blog.pages | slice(end=5) %}


### PR DESCRIPTION
## Problemas

**#89** — La foto portada en la home estaba hardcodeada en `_index.md` apuntando a una foto vieja (`tupicenos`, de 2008), en lugar de mostrar la más reciente.

**#88** — El borde del media-frame en el sidebar usaba `border-2` en todos los lados, creando un borde lateral raro que se solapaba visualmente con el divisor de columna del sidebar.

Fixes #88, #89

## Solución

- `templates/index.html`: obtiene la foto portada dinámicamente desde `get_section(path="fotos/_index.md").pages | first`, que devuelve la más reciente (la sección ordena por fecha descendente)
- `src/styles/site.css`: cambia `.home-sidebar .media-frame` de `border-2` a `border-t-2 border-black`, poniendo solo un borde superior de acento en lugar de un marco completo

## Test plan

- [ ] Verificar que la foto en la home muestra la foto más reciente de `/fotos/`
- [ ] Verificar que la foto tiene borde solo en la parte superior (sin borde lateral raro)
- [ ] Verificar que el divisor de columna del sidebar sigue viéndose bien

🤖 Generated with [Claude Code](https://claude.com/claude-code)