### PR TITLE
Fix #10: refrescar comentarios recientes en portada

### DIFF
--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -210,6 +210,33 @@ async function loadRecentComments(container) {
   }
 }
 
+const RECENT_COMMENTS_REFRESH_KEY = "typ:last-comment-at";
+
+function announceRecentCommentRefresh() {
+  try {
+    localStorage.setItem(RECENT_COMMENTS_REFRESH_KEY, String(Date.now()));
+  } catch (_e) {
+    // Best-effort only.
+  }
+  window.dispatchEvent(new CustomEvent("typ:recent-comments-refresh"));
+}
+
+function bindRecentCommentsRefresh(container) {
+  const refresh = () => {
+    loadRecentComments(container);
+  };
+
+  refresh();
+
+  window.addEventListener("pageshow", refresh);
+  window.addEventListener("typ:recent-comments-refresh", refresh);
+  window.addEventListener("storage", (event) => {
+    if (event.key === RECENT_COMMENTS_REFRESH_KEY) {
+      refresh();
+    }
+  });
+}
+
 function bindCommentForm(form, dynamicContainer, slug) {
   const status = form.querySelector("[data-status]");
   form.addEventListener("submit", async (e) => {
@@ -240,6 +267,7 @@ function bindCommentForm(form, dynamicContainer, slug) {
       status.dataset.state = "ok";
       form.reset();
       await loadDynamicComments(dynamicContainer, slug);
+      announceRecentCommentRefresh();
     } catch (_e) {
       status.textContent = "Error de red. Probá más tarde.";
       status.dataset.state = "error";
@@ -259,5 +287,5 @@ if (dynamicContainer && commentForm) {
 
 const recentCommentsContainer = document.querySelector("[data-recent-comments]");
 if (recentCommentsContainer) {
-  loadRecentComments(recentCommentsContainer);
+  bindRecentCommentsRefresh(recentCommentsContainer);
 }

--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -228,7 +228,11 @@ function bindRecentCommentsRefresh(container) {
 
   refresh();
 
-  window.addEventListener("pageshow", refresh);
+  window.addEventListener("pageshow", (event) => {
+    if (event.persisted) {
+      refresh();
+    }
+  });
   window.addEventListener("typ:recent-comments-refresh", refresh);
   window.addEventListener("storage", (event) => {
     if (event.key === RECENT_COMMENTS_REFRESH_KEY) {


### PR DESCRIPTION
Resuelve #10.

Qué cambia:
- vuelve a consultar la API de comentarios recientes al volver a la portada desde el cache del navegador
- emite un evento de refresh cuando se publica un comentario nuevo
- escucha cambios cross-tab para mantener el módulo de portada sincronizado

Verificación:
- `npm run build`
