### PR TITLE
fix: eliminar borde lateral del sidebar de home

### DIFF
--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -621,7 +621,7 @@
   }
 
   .home-sidebar {
-    @apply min-w-0 lg:border-l lg:border-black lg:pl-10;
+    @apply min-w-0 lg:pl-10;
   }
 
   .home-lead {


### PR DESCRIPTION
## Problema

El `border-l` en `.home-sidebar` generaba una línea vertical en el borde izquierdo del sidebar que se veía mal, especialmente junto a la foto portada.

Fixes #88

## Solución

Elimina `lg:border-l lg:border-black` de `.home-sidebar`. El `gap-10` del grid ya provee separación visual suficiente entre las columnas sin necesitar un borde explícito.

🤖 Generated with [Claude Code](https://claude.com/claude-code)