### PR TITLE
Feat #13: subsecciones navegables para el blog

### DIFF
--- a/content/blog/subsecciones/_index.md
+++ b/content/blog/subsecciones/_index.md
@@ -1,0 +1,10 @@
++++
+title = "Subsecciones"
+sort_by = "title"
+template = "blog_subsections.html"
+
+[extra]
+summary = "Recorridos internos del blog organizados por la primera etiqueta editorial de cada texto."
++++
+
+Subsecciones internas del blog.

--- a/content/blog/subsecciones/amistad.md
+++ b/content/blog/subsecciones/amistad.md
@@ -1,0 +1,16 @@
++++
+title = "Amistad"
+template = "blog_subsection.html"
+
+[extra]
+subsection_slug = "amistad"
+article_paths = [
+    "blog/con-tanta-noche-por-la-ventana.md",
+    "blog/no-pudieron.md",
+    "blog/pequenas-historias-facebookianas.md",
+    "blog/treinta-y-ocho.md",
+    "blog/un-cuaderno-en-el-cajon.md",
+]
++++
+
+Selección de textos del blog bajo la subsección Amistad.

--- a/content/blog/subsecciones/amor.md
+++ b/content/blog/subsecciones/amor.md
@@ -1,0 +1,12 @@
++++
+title = "Amor"
+template = "blog_subsection.html"
+
+[extra]
+subsection_slug = "amor"
+article_paths = [
+    "blog/carta-para-reenamorar.md",
+]
++++
+
+Selección de textos del blog bajo la subsección Amor.

--- a/content/blog/subsecciones/anecdotas.md
+++ b/content/blog/subsecciones/anecdotas.md
@@ -1,0 +1,15 @@
++++
+title = "Anécdotas"
+template = "blog_subsection.html"
+
+[extra]
+subsection_slug = "anecdotas"
+article_paths = [
+    "blog/bienvenida-al-club.md",
+    "blog/carta-a-un-daniel-riera.md",
+    "blog/el-choque.md",
+    "blog/el-pibe-del-pool.md",
+]
++++
+
+No hay fracaso más rotundo / que haberse venido al mundo / pa´ morirse y nada más...

--- a/content/blog/subsecciones/aprendizajes.md
+++ b/content/blog/subsecciones/aprendizajes.md
@@ -1,0 +1,17 @@
++++
+title = "Aprendizajes"
+template = "blog_subsection.html"
+
+[extra]
+subsection_slug = "aprendizajes"
+article_paths = [
+    "blog/aiti.md",
+    "blog/cuando-el-imbecil-tiene-la-razon.md",
+    "blog/el-gol-no-esta-hecho.md",
+    "blog/el-taller-gimnasio-de-la-neurona.md",
+    "blog/fragmentos-de-una-despedida.md",
+    "blog/la-especialidad-de-la-casa.md",
+]
++++
+
+Nadie nace sabiendo, ni sabe naciendo. Y esta parte de mi vida está plagada de aprendizajes que quiero compartir.

--- a/content/blog/subsecciones/carta.md
+++ b/content/blog/subsecciones/carta.md
@@ -1,0 +1,13 @@
++++
+title = "Carta"
+template = "blog_subsection.html"
+
+[extra]
+subsection_slug = "carta"
+article_paths = [
+    "blog/cuando-dejamos-de-sonar-con-ser-un-pais.md",
+    "blog/lo-que-quiero.md",
+]
++++
+
+Selección de textos del blog bajo la subsección Carta.

--- a/content/blog/subsecciones/cinefileando.md
+++ b/content/blog/subsecciones/cinefileando.md
@@ -1,0 +1,14 @@
++++
+title = "Cinefileando"
+template = "blog_subsection.html"
+
+[extra]
+subsection_slug = "cinefileando"
+article_paths = [
+    "blog/contrastes.md",
+    "blog/cosas-que-dan-ganas-de-hacer-luego.md",
+    "blog/nos-reimos-de-perdon-con-ustedes.md",
+]
++++
+
+Selección de textos del blog bajo la subsección Cinefileando.

--- a/content/blog/subsecciones/desde-el-ombligo.md
+++ b/content/blog/subsecciones/desde-el-ombligo.md
@@ -1,0 +1,24 @@
++++
+title = "Desde el ombligo"
+template = "blog_subsection.html"
+
+[extra]
+subsection_slug = "desde-el-ombligo"
+article_paths = [
+    "blog/cartas-de-amor-efimero-iii.md",
+    "blog/contener-la-respiracion.md",
+    "blog/de-alegrias-y-de-abrazos.md",
+    "blog/dulce-y-tenaz.md",
+    "blog/evolucion.md",
+    "blog/la-parte-mas-nerd.md",
+    "blog/lo-imprescindible.md",
+    "blog/normalidad.md",
+    "blog/pasar.md",
+    "blog/quedarse.md",
+    "blog/querida-cami.md",
+    "blog/razones.md",
+    "blog/una-decada-de-impunidad.md",
+]
++++
+
+Textos intimamente publicos

--- a/content/blog/subsecciones/el-resto.md
+++ b/content/blog/subsecciones/el-resto.md
@@ -1,0 +1,42 @@
++++
+title = "El resto"
+template = "blog_subsection.html"
+
+[extra]
+subsection_slug = "el-resto"
+article_paths = [
+    "blog/actitudes.md",
+    "blog/articulo-82.md",
+    "blog/autofoto-jpg.md",
+    "blog/cable.md",
+    "blog/collage-de-cinismos.md",
+    "blog/complices.md",
+    "blog/el-club-de-amigos.md",
+    "blog/el-enganador.md",
+    "blog/el-hugo.md",
+    "blog/en-tiempo-real.md",
+    "blog/historias-de-esso-shop.md",
+    "blog/insomnios.md",
+    "blog/irse.md",
+    "blog/la-otra-dictadura.md",
+    "blog/lema.md",
+    "blog/literatura-urbana.md",
+    "blog/llegar.md",
+    "blog/lo-triste-de-no-creer.md",
+    "blog/papa-lee-a-tin.md",
+    "blog/pretexto.md",
+    "blog/quien-te-manda.md",
+    "blog/relato-de-un-narrador.md",
+    "blog/ruido-molesto.md",
+    "blog/semana.md",
+    "blog/sobre-el-autor.md",
+    "blog/suerte.md",
+    "blog/tramites.md",
+    "blog/tres-grageas-para-mama.md",
+    "blog/un-mes.md",
+    "blog/una-carta-para-joaquin.md",
+    "blog/viaje.md",
+]
++++
+
+Cuando por alguna razón, las palabras se sientan incomodas en otra sección, acá irán a parar.

--- a/content/blog/subsecciones/familia.md
+++ b/content/blog/subsecciones/familia.md
@@ -1,0 +1,13 @@
++++
+title = "Familia"
+template = "blog_subsection.html"
+
+[extra]
+subsection_slug = "familia"
+article_paths = [
+    "blog/el-termo.md",
+    "blog/trescientos-metros.md",
+]
++++
+
+Selección de textos del blog bajo la subsección Familia.

--- a/content/blog/subsecciones/ficciones.md
+++ b/content/blog/subsecciones/ficciones.md
@@ -1,0 +1,22 @@
++++
+title = "Ficciones"
+template = "blog_subsection.html"
+
+[extra]
+subsection_slug = "ficciones"
+article_paths = [
+    "blog/azul-mi-amor-de-invierno.md",
+    "blog/hazanas-zarpadas.md",
+    "blog/identidad.md",
+    "blog/la-abuela-de-pedro.md",
+    "blog/la-ciruela-magica.md",
+    "blog/la-habitacion.md",
+    "blog/los-mimos-y-las-masas.md",
+    "blog/mi-carrera-secreta.md",
+    "blog/poco-cambio.md",
+    "blog/verdes-menesteres.md",
+    "blog/yo-payaso.md",
+]
++++
+
+Selección de textos del blog bajo la subsección Ficciones.

--- a/content/blog/subsecciones/gente.md
+++ b/content/blog/subsecciones/gente.md
@@ -1,0 +1,16 @@
++++
+title = "Gente"
+template = "blog_subsection.html"
+
+[extra]
+subsection_slug = "gente"
+article_paths = [
+    "blog/aparte-de-puto.md",
+    "blog/el-abrazo-caracol.md",
+    "blog/gordo.md",
+    "blog/la-clase-de-manejo.md",
+    "blog/mavi.md",
+]
++++
+
+Lo más hermoso de vivir acá es conocer gente. Pongansé cómodos que los presento.

--- a/content/blog/subsecciones/huellas.md
+++ b/content/blog/subsecciones/huellas.md
@@ -1,0 +1,14 @@
++++
+title = "huellas"
+template = "blog_subsection.html"
+
+[extra]
+subsection_slug = "huellas"
+article_paths = [
+    "blog/ferpecto-quilombo.md",
+    "blog/ganas.md",
+    "blog/unos-diitas-despues-de-la.md",
+]
++++
+
+Selección de textos del blog bajo la subsección huellas.

--- a/content/blog/subsecciones/la-pelota-no-se-mancha.md
+++ b/content/blog/subsecciones/la-pelota-no-se-mancha.md
@@ -1,0 +1,12 @@
++++
+title = "La pelota no se mancha"
+template = "blog_subsection.html"
+
+[extra]
+subsection_slug = "la-pelota-no-se-mancha"
+article_paths = [
+    "blog/fideo.md",
+]
++++
+
+Selección de textos del blog bajo la subsección La pelota no se mancha.

--- a/content/blog/subsecciones/memoria.md
+++ b/content/blog/subsecciones/memoria.md
@@ -1,0 +1,12 @@
++++
+title = "Memoria"
+template = "blog_subsection.html"
+
+[extra]
+subsection_slug = "memoria"
+article_paths = [
+    "blog/felices-quince.md",
+]
++++
+
+Selección de textos del blog bajo la subsección Memoria.

--- a/content/blog/subsecciones/musica.md
+++ b/content/blog/subsecciones/musica.md
@@ -1,0 +1,12 @@
++++
+title = "Música"
+template = "blog_subsection.html"
+
+[extra]
+subsection_slug = "musica"
+article_paths = [
+    "blog/a-ver.md",
+]
++++
+
+Selección de textos del blog bajo la subsección Música.

--- a/content/blog/subsecciones/opinion-o-pinon.md
+++ b/content/blog/subsecciones/opinion-o-pinon.md
@@ -1,0 +1,15 @@
++++
+title = "Opinión o piñón"
+template = "blog_subsection.html"
+
+[extra]
+subsection_slug = "opinion-o-pinon"
+article_paths = [
+    "blog/carta-abierta-cordoba.md",
+    "blog/cuatro-fragmentos-de-una-muerte.md",
+    "blog/el-otro-bombardeo.md",
+    "blog/por-que-vamos-a-la-marcha.md",
+]
++++
+
+Selección de textos del blog bajo la subsección Opinión o piñón.

--- a/content/blog/subsecciones/poesia.md
+++ b/content/blog/subsecciones/poesia.md
@@ -1,0 +1,14 @@
++++
+title = "Poesía"
+template = "blog_subsection.html"
+
+[extra]
+subsection_slug = "poesia"
+article_paths = [
+    "blog/ascenso.md",
+    "blog/poemario-de-una-breve-eternidad.md",
+    "blog/puedo.md",
+]
++++
+
+Selección de textos del blog bajo la subsección Poesía.

--- a/content/blog/subsecciones/politica.md
+++ b/content/blog/subsecciones/politica.md
@@ -1,0 +1,12 @@
++++
+title = "Política"
+template = "blog_subsection.html"
+
+[extra]
+subsection_slug = "politica"
+article_paths = [
+    "blog/del-amor-y-otras-politicas.md",
+]
++++
+
+Selección de textos del blog bajo la subsección Política.

--- a/content/blog/subsecciones/tecnologia.md
+++ b/content/blog/subsecciones/tecnologia.md
@@ -1,0 +1,14 @@
++++
+title = "Tecnología"
+template = "blog_subsection.html"
+
+[extra]
+subsection_slug = "tecnologia"
+article_paths = [
+    "blog/aprietes.md",
+    "blog/hurgando-en-el-gmail.md",
+    "blog/mirenlo-a-el-que-blogudo.md",
+]
++++
+
+Selección de textos del blog bajo la subsección Tecnología.

--- a/content/blog/subsecciones/universo-universitario.md
+++ b/content/blog/subsecciones/universo-universitario.md
@@ -1,0 +1,24 @@
++++
+title = "Universo universitario"
+template = "blog_subsection.html"
+
+[extra]
+subsection_slug = "universo-universitario"
+article_paths = [
+    "blog/carta-abierta-a-mis-companeros.md",
+    "blog/distinto.md",
+    "blog/el-golpe-esta-en-marcha.md",
+    "blog/i-m-back.md",
+    "blog/limando-cantos-i.md",
+    "blog/limando-cantos-ii.md",
+    "blog/limando-cantos-iii.md",
+    "blog/limando-cantos-iv.md",
+    "blog/mas-de-30-mil.md",
+    "blog/resabios-del-demonio.md",
+    "blog/sobre-la-obligatoriedad-de-la-pps.md",
+    "blog/sobreviviente.md",
+    "blog/tin-contra-el-sistema.md",
+]
++++
+
+Hay cosas que sólo pueden ocurrir en la universidad, y acá las cuento.

--- a/content/blog/subsecciones/viajero.md
+++ b/content/blog/subsecciones/viajero.md
@@ -1,0 +1,15 @@
++++
+title = "Viajero"
+template = "blog_subsection.html"
+
+[extra]
+subsection_slug = "viajero"
+article_paths = [
+    "blog/buscando-la-paz-de-la-paz.md",
+    "blog/cartas-de-amor-efimero-i.md",
+    "blog/cartas-de-amor-efimero-ii.md",
+    "blog/waliki.md",
+]
++++
+
+Selección de textos del blog bajo la subsección Viajero.

--- a/content/blog/subsecciones/yo-lo-vide.md
+++ b/content/blog/subsecciones/yo-lo-vide.md
@@ -1,0 +1,19 @@
++++
+title = "Yo lo vide"
+template = "blog_subsection.html"
+
+[extra]
+subsection_slug = "yo-lo-vide"
+article_paths = [
+    "blog/bienvenidos-al-show.md",
+    "blog/bolivia.md",
+    "blog/dedicatorias.md",
+    "blog/el-senor-triste.md",
+    "blog/hoy-es-un-dia-fresquito.md",
+    "blog/la-caja-de-manzanas.md",
+    "blog/los-dientes-del-poder.md",
+    "blog/regalo-de-cumpleanos.md",
+]
++++
+
+— Yo lo vide en el noticiero — dice la Negra, dando a entender que «vió> algo.  En el mundo hay tanto, pero tanto para ver y hacer que, si fuese posible ser justo escribiendo para esta sección, no me quedaria tiempo para hacer ver cosas porque sólo escribiría. Qué paradoja.

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -559,6 +559,19 @@
     border-color: var(--color-link);
   }
 
+  .subsection-strip {
+    @apply flex flex-wrap gap-3;
+  }
+
+  .subsection-chip {
+    font-family: var(--font-ui);
+    @apply border border-black px-3 py-2 text-[11px] uppercase tracking-[0.18em] text-black transition-colors hover:bg-black hover:text-white;
+  }
+
+  .subsection-chip.is-active {
+    @apply bg-black text-white;
+  }
+
   .page-footer {
     @apply mt-16 border-t border-black pt-5 text-[11px] uppercase tracking-[0.22em] text-neutral-500;
     font-family: var(--font-mono);

--- a/templates/article.html
+++ b/templates/article.html
@@ -8,7 +8,11 @@
   {% set use_subcat = page.extra.section_slug in ["blog", "de-otros"] and page.extra.tag_links and page.extra.tag_links | length > 0 %}
   {% if use_subcat %}
     {% set kicker_text = page.extra.tag_links[0].name %}
-    {% set kicker_link = page.extra.tag_links[0].path %}
+    {% if page.extra.section_slug == "blog" %}
+      {% set kicker_link = page.extra.tag_links[0].path | replace(from="/etiquetas/", to="/blog/subsecciones/") %}
+    {% else %}
+      {% set kicker_link = page.extra.tag_links[0].path %}
+    {% endif %}
   {% else %}
     {% set kicker_text = page.extra.section_title %}
     {% set kicker_link = "/" ~ page.extra.section_slug ~ "/" %}

--- a/templates/blog_subsection.html
+++ b/templates/blog_subsection.html
@@ -1,0 +1,44 @@
+{% extends "base.html" %}
+{% import "partials/macros.html" as macros %}
+
+{% block title %}{{ page.title }} · Blog · {{ config.title }}{% endblock title %}
+{% block meta_description %}{{ page.content | striptags | truncate(length=160) | default(value="Subsección del blog") }}{% endblock meta_description %}
+
+{% block content %}
+  {% set subsections = get_section(path="blog/subsecciones/_index.md") %}
+  {% set blog = get_section(path="blog/_index.md") %}
+
+  <main class="pt-8">
+    <section class="editorial-rule">
+      <span class="section-ribbon">Subsección</span>
+      <div class="mt-5 max-w-[56rem]">
+        <p class="story-kicker"><a href="/blog/">Blog</a></p>
+        <h1 class="story-title">{{ page.title }}</h1>
+        {% if page.content %}
+          <div class="story-content mt-6">{{ page.content | safe }}</div>
+        {% endif %}
+      </div>
+    </section>
+
+    {% if subsections.pages | length > 0 %}
+      <section class="editorial-rule mt-8">
+        <div class="subsection-strip">
+          {% for subsection in subsections.pages | sort(attribute="title") %}
+            <a
+              href="{{ subsection.permalink }}"
+              class="subsection-chip{% if subsection.permalink == page.permalink %} is-active{% endif %}"
+            >{{ subsection.title }}</a>
+          {% endfor %}
+        </div>
+      </section>
+    {% endif %}
+
+    <section class="listing mt-10">
+      {% for article in blog.pages %}
+        {% if article.tags and article.tags[0] == page.title %}
+          {{ macros::story_card(page=article, variant="list") }}
+        {% endif %}
+      {% endfor %}
+    </section>
+  </main>
+{% endblock content %}

--- a/templates/blog_subsection.html
+++ b/templates/blog_subsection.html
@@ -35,7 +35,7 @@
 
     <section class="listing mt-10">
       {% for article in blog.pages %}
-        {% if article.tags and article.tags[0] == page.title %}
+        {% if page.extra.article_paths and article.relative_path and article.relative_path in page.extra.article_paths %}
           {{ macros::story_card(page=article, variant="list") }}
         {% endif %}
       {% endfor %}

--- a/templates/blog_subsections.html
+++ b/templates/blog_subsections.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+
+{% block title %}Subsecciones · Blog · {{ config.title }}{% endblock title %}
+{% block meta_description %}{{ section.extra.summary | default(value="Subsecciones del blog") }}{% endblock meta_description %}
+
+{% block content %}
+  <main class="pt-8">
+    <section class="editorial-rule">
+      <span class="section-ribbon">Blog</span>
+      <div class="mt-5 max-w-[56rem]">
+        <p class="story-kicker"><a href="/blog/">Volver al listado general</a></p>
+        <h1 class="story-title">{{ section.title }}</h1>
+        {% if section.content %}
+          <div class="story-content mt-6">{{ section.content | safe }}</div>
+        {% elif section.extra.summary %}
+          <p class="story-deck">{{ section.extra.summary }}</p>
+        {% endif %}
+      </div>
+    </section>
+
+    <section class="taxonomy-grid mt-10">
+      {% for page in section.pages | sort(attribute="title") %}
+        <article class="taxonomy-card reveal">
+          <p class="story-kicker">Subsección</p>
+          <h2 class="story-title-xs"><a href="{{ page.permalink }}">{{ page.title }}</a></h2>
+          <p class="mt-4 text-base leading-7 text-neutral-700">{{ page.extra.article_paths | length }} textos</p>
+        </article>
+      {% endfor %}
+    </section>
+  </main>
+{% endblock content %}

--- a/templates/partials/macros.html
+++ b/templates/partials/macros.html
@@ -6,8 +6,14 @@
   {% set use_subcat = page.extra.section_slug in ["blog", "de-otros"] and page.extra.tag_links and page.extra.tag_links | length > 0 %}
   {% if use_subcat %}
     {% set kicker_text = page.extra.tag_links[0].name %}
+    {% if page.extra.section_slug == "blog" %}
+      {% set kicker_link = page.extra.tag_links[0].path | replace(from="/etiquetas/", to="/blog/subsecciones/") %}
+    {% else %}
+      {% set kicker_link = page.extra.tag_links[0].path %}
+    {% endif %}
   {% else %}
     {% set kicker_text = page.extra.section_title %}
+    {% set kicker_link = "/" ~ page.extra.section_slug ~ "/" %}
   {% endif %}
   <article class="{% if is_list %}listing-card{% elif is_home_list %}home-listing-card{% elif is_compact %}feed-item{% else %}grid gap-5{% endif %}{% if not page.extra.hero_image %} no-media{% endif %}">
     {% if page.extra.hero_image %}
@@ -20,7 +26,11 @@
       </a>
     {% endif %}
     <div class="reveal">
-      {% if not is_compact %}<p class="story-kicker">{{ kicker_text }}</p>{% endif %}
+      {% if not is_compact %}
+        <p class="story-kicker">
+          {% if kicker_link %}<a href="{{ kicker_link }}">{{ kicker_text }}</a>{% else %}{{ kicker_text }}{% endif %}
+        </p>
+      {% endif %}
       <h2 class="{% if is_feature %}story-title{% elif is_compact %}story-title-xs{% elif is_list %}story-title-sm{% else %}story-title-sm{% endif %}">
         <a href="{{ page.permalink }}">{{ page.title }}</a>
       </h2>

--- a/templates/section.html
+++ b/templates/section.html
@@ -6,6 +6,9 @@
 
 {% block content %}
   <main class="pt-8">
+    {% if section.extra.section_slug == "blog" %}
+      {% set blog_subsections = get_section(path="blog/subsecciones/_index.md") %}
+    {% endif %}
     <section class="editorial-rule">
       <div class="mt-5 max-w-[52rem]">
         <h1 class="story-title">{{ section.title }}</h1>
@@ -16,6 +19,20 @@
         {% endif %}
       </div>
     </section>
+
+    {% if section.extra.section_slug == "blog" and blog_subsections.pages | length > 0 %}
+      <section class="editorial-rule mt-8">
+        <div class="flex items-center justify-between gap-4">
+          <h2 class="module-title mb-0">Subsecciones</h2>
+          <a class="more-link" href="{{ blog_subsections.permalink }}">Ver todas</a>
+        </div>
+        <div class="subsection-strip mt-6">
+          {% for subsection in blog_subsections.pages | sort(attribute="title") %}
+            <a href="{{ subsection.permalink }}" class="subsection-chip">{{ subsection.title }}</a>
+          {% endfor %}
+        </div>
+      </section>
+    {% endif %}
 
     <section class="listing mt-10">
       {% for page in section.pages %}


### PR DESCRIPTION
Resuelve #13.

Criterio elegido:
- la subsección del blog se define por la primera etiqueta editorial de cada post
- se crean páginas propias bajo `/blog/subsecciones/<slug>/` con listado exclusivo de posts del blog
- `/blog/` muestra un bloque de navegación a subsecciones y los kickers del blog enlazan a esas páginas

Qué incluye:
- templates nuevos para índice de subsecciones y página de subsección
- generación de páginas de subsección a partir de la metadata actual
- enlaces consistentes desde cards y artículos del blog

Verificación:
- `npm run build`
