### PR TITLE
Feat #16: modo oscuro con toggle sol/luna

### DIFF
--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -4,6 +4,46 @@ const root = document.documentElement;
 const body = document.body;
 const navToggle = document.querySelector("[data-nav-toggle]");
 const navPanel = document.querySelector("[data-nav-panel]");
+const themeToggle = document.querySelector("[data-theme-toggle]");
+const THEME_STORAGE_KEY = "typ:theme";
+
+function resolveThemePreference() {
+  const saved = root.dataset.theme;
+  if (saved === "dark" || saved === "light") {
+    return saved;
+  }
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+function syncThemeToggle(theme) {
+  if (!themeToggle) return;
+  const isDark = theme === "dark";
+  themeToggle.setAttribute("aria-pressed", String(isDark));
+  themeToggle.dataset.theme = theme;
+  themeToggle.querySelector("[data-theme-icon]")?.replaceChildren(document.createTextNode(isDark ? "☀" : "☾"));
+  themeToggle.querySelector("[data-theme-label]")?.replaceChildren(
+    document.createTextNode(isDark ? "Modo claro" : "Modo oscuro")
+  );
+}
+
+function applyTheme(theme) {
+  root.dataset.theme = theme;
+  syncThemeToggle(theme);
+}
+
+applyTheme(resolveThemePreference());
+
+if (themeToggle) {
+  themeToggle.addEventListener("click", () => {
+    const nextTheme = root.dataset.theme === "dark" ? "light" : "dark";
+    applyTheme(nextTheme);
+    try {
+      localStorage.setItem(THEME_STORAGE_KEY, nextTheme);
+    } catch (_e) {
+      // Ignore persistence failures.
+    }
+  });
+}
 
 if (navToggle && navPanel) {
   navToggle.addEventListener("click", () => {

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -14,6 +14,9 @@
   --color-border: #d7dbe1;
   --color-muted: #757575;
   --color-panel: #f5f5f1;
+  --color-grid: rgba(0, 0, 0, 0.03);
+  --color-sheen: rgba(0, 0, 0, 0.015);
+  --color-selection: rgba(5, 125, 188, 0.16);
 }
 
 @layer base {
@@ -24,14 +27,29 @@
   html {
     background: var(--color-paper);
     color: var(--color-ink);
+    color-scheme: light;
+  }
+
+  html[data-theme="dark"] {
+    --color-paper: #101417;
+    --color-ink: #f3ede3;
+    --color-black: #f3ede3;
+    --color-link: #78c3ef;
+    --color-border: #3a4348;
+    --color-muted: #b6aea1;
+    --color-panel: #171d21;
+    --color-grid: rgba(255, 255, 255, 0.05);
+    --color-sheen: rgba(255, 255, 255, 0.04);
+    --color-selection: rgba(120, 195, 239, 0.28);
+    color-scheme: dark;
   }
 
   body {
     font-family: var(--font-body);
     margin: 0;
     background:
-      linear-gradient(180deg, rgba(0, 0, 0, 0.03) 0, rgba(0, 0, 0, 0.03) 1px, transparent 1px, transparent 100%),
-      linear-gradient(90deg, rgba(0, 0, 0, 0.03) 0, rgba(0, 0, 0, 0.03) 1px, transparent 1px, transparent 100%),
+      linear-gradient(180deg, var(--color-grid) 0, var(--color-grid) 1px, transparent 1px, transparent 100%),
+      linear-gradient(90deg, var(--color-grid) 0, var(--color-grid) 1px, transparent 1px, transparent 100%),
       var(--color-paper);
     background-size: 100% 8px, 8px 100%, auto;
   }
@@ -45,7 +63,7 @@
     position: fixed;
     inset: 0;
     pointer-events: none;
-    background: linear-gradient(180deg, rgba(0, 0, 0, 0.015), transparent 22rem);
+    background: linear-gradient(180deg, var(--color-sheen), transparent 22rem);
   }
 
   a {
@@ -65,7 +83,7 @@
   }
 
   ::selection {
-    background: rgba(5, 125, 188, 0.16);
+    background: var(--color-selection);
   }
 }
 
@@ -81,6 +99,10 @@
 
   .utility-links {
     @apply flex flex-wrap items-center gap-x-4 gap-y-2;
+  }
+
+  .utility-actions {
+    @apply flex items-center gap-3;
   }
 
   .masthead {
@@ -133,6 +155,15 @@
 
   .nav-panel[data-open="true"] {
     @apply block;
+  }
+
+  .theme-toggle {
+    font-family: var(--font-ui);
+    @apply inline-flex items-center gap-2 border border-white/50 px-2.5 py-1 text-[10px] uppercase tracking-[0.2em] text-white transition-colors hover:bg-white hover:text-black;
+  }
+
+  .theme-toggle-icon {
+    @apply text-sm leading-none;
   }
 
   .section-ribbon {
@@ -682,4 +713,148 @@
   .search-form button:hover {
     @apply opacity-70;
   }
+}
+
+html[data-theme="dark"] body {
+  color: var(--color-ink);
+}
+
+html[data-theme="dark"] .utility-bar,
+html[data-theme="dark"] .masthead,
+html[data-theme="dark"] .main-nav,
+html[data-theme="dark"] .nav-panel,
+html[data-theme="dark"] .media-frame,
+html[data-theme="dark"] .taxonomy-card,
+html[data-theme="dark"] .comment-field input,
+html[data-theme="dark"] .comment-field textarea,
+html[data-theme="dark"] .comment-form .btn-submit,
+html[data-theme="dark"] .nav-toggle,
+html[data-theme="dark"] .subsection-chip {
+  background: var(--color-panel);
+}
+
+html[data-theme="dark"] .utility-bar,
+html[data-theme="dark"] .masthead,
+html[data-theme="dark"] .main-nav,
+html[data-theme="dark"] .nav-panel,
+html[data-theme="dark"] .editorial-rule,
+html[data-theme="dark"] .listing,
+html[data-theme="dark"] .feed-item,
+html[data-theme="dark"] .index-list,
+html[data-theme="dark"] .index-row,
+html[data-theme="dark"] .comment-snippet,
+html[data-theme="dark"] .comment-card,
+html[data-theme="dark"] .comment-form,
+html[data-theme="dark"] .article-nav,
+html[data-theme="dark"] .taxonomy-card,
+html[data-theme="dark"] .page-footer,
+html[data-theme="dark"] .sidebar-block,
+html[data-theme="dark"] .home-sidebar,
+html[data-theme="dark"] .comment-field input,
+html[data-theme="dark"] .comment-field textarea,
+html[data-theme="dark"] .comment-form .btn-submit,
+html[data-theme="dark"] .nav-toggle,
+html[data-theme="dark"] .subsection-chip,
+html[data-theme="dark"] .story-content blockquote,
+html[data-theme="dark"] .story-content .poetry,
+html[data-theme="dark"] .article-tags a,
+html[data-theme="dark"] .image-modal-figure {
+  border-color: var(--color-border) !important;
+}
+
+html[data-theme="dark"] .story-title,
+html[data-theme="dark"] .story-title-sm,
+html[data-theme="dark"] .story-title-xs,
+html[data-theme="dark"] .brand-title,
+html[data-theme="dark"] .module-title,
+html[data-theme="dark"] .nav-link,
+html[data-theme="dark"] .story-content,
+html[data-theme="dark"] .comment-field input,
+html[data-theme="dark"] .comment-field textarea,
+html[data-theme="dark"] .comment-form .btn-submit {
+  color: var(--color-ink) !important;
+}
+
+html[data-theme="dark"] .story-deck,
+html[data-theme="dark"] .article-subtitle,
+html[data-theme="dark"] .article-deck,
+html[data-theme="dark"] .comment-body,
+html[data-theme="dark"] .brand-deck,
+html[data-theme="dark"] .brand-eyebrow,
+html[data-theme="dark"] .story-kicker,
+html[data-theme="dark"] .meta-row,
+html[data-theme="dark"] .page-footer,
+html[data-theme="dark"] .article-contribute,
+html[data-theme="dark"] .comment-form-status,
+html[data-theme="dark"] .story-content blockquote,
+html[data-theme="dark"] .story-content figcaption,
+html[data-theme="dark"] .no-comments-placeholder,
+html[data-theme="dark"] .text-neutral-700,
+html[data-theme="dark"] .text-neutral-600,
+html[data-theme="dark"] .text-neutral-500,
+html[data-theme="dark"] .text-neutral-400,
+html[data-theme="dark"] .text-neutral-300 {
+  color: var(--color-muted) !important;
+}
+
+html[data-theme="dark"] .section-ribbon {
+  background: var(--color-ink);
+  color: var(--color-paper);
+}
+
+html[data-theme="dark"] .home-blog-rest .feed-item,
+html[data-theme="dark"] .home-blog-rest .home-listing-card,
+html[data-theme="dark"] .comment-stack,
+html[data-theme="dark"] .sidebar-block {
+  border-color: var(--color-border) !important;
+}
+
+html[data-theme="dark"] .comment-stack {
+  --tw-divide-opacity: 1;
+  border-color: var(--color-border) !important;
+}
+
+html[data-theme="dark"] .theme-toggle {
+  border-color: rgba(243, 237, 227, 0.45);
+  color: var(--color-ink);
+}
+
+html[data-theme="dark"] .theme-toggle:hover,
+html[data-theme="dark"] .comment-form .btn-submit:hover,
+html[data-theme="dark"] .subsection-chip:hover,
+html[data-theme="dark"] .nav-toggle:hover {
+  background: var(--color-ink);
+  color: var(--color-paper) !important;
+}
+
+html[data-theme="dark"] .search-form input[type="search"] {
+  border-bottom-color: rgba(243, 237, 227, 0.5);
+  color: var(--color-ink);
+}
+
+html[data-theme="dark"] .search-form input[type="search"]::placeholder {
+  color: rgba(243, 237, 227, 0.55);
+}
+
+html[data-theme="dark"] .search-form button,
+html[data-theme="dark"] .image-modal-close {
+  border-color: rgba(243, 237, 227, 0.5);
+  color: var(--color-ink);
+}
+
+html[data-theme="dark"] .image-modal-close {
+  background: var(--color-panel);
+}
+
+html[data-theme="dark"] .image-modal-close:hover {
+  background: var(--color-ink);
+  color: var(--color-paper);
+}
+
+html[data-theme="dark"] .comment-form-status[data-state="ok"] {
+  color: #8ed7a8 !important;
+}
+
+html[data-theme="dark"] .comment-form-status[data-state="error"] {
+  color: #ff9d9d !important;
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -9,14 +9,15 @@
     <script>
       (() => {
         const storageKey = "typ:theme";
+        const fallbackTheme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
         try {
           const saved = localStorage.getItem(storageKey);
           const theme = saved === "dark" || saved === "light"
             ? saved
-            : (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+            : fallbackTheme;
           document.documentElement.dataset.theme = theme;
         } catch (_error) {
-          document.documentElement.dataset.theme = "light";
+          document.documentElement.dataset.theme = fallbackTheme;
         }
       })();
     </script>

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,6 +6,20 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block title %}{{ config.title }}{% endblock title %}</title>
     <meta name="description" content="{% block meta_description %}{{ config.description }}{% endblock meta_description %}">
+    <script>
+      (() => {
+        const storageKey = "typ:theme";
+        try {
+          const saved = localStorage.getItem(storageKey);
+          const theme = saved === "dark" || saved === "light"
+            ? saved
+            : (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+          document.documentElement.dataset.theme = theme;
+        } catch (_error) {
+          document.documentElement.dataset.theme = "light";
+        }
+      })();
+    </script>
     <link rel="stylesheet" href="/assets/site.css">
     <script type="module" src="/assets/site.js"></script>
     <link rel="alternate" type="application/atom+xml" title="{{ config.title }}" href="{{ get_url(path='atom.xml') }}">
@@ -18,11 +32,17 @@
           <a href="/autores/">Autores</a>
           <a href="/etiquetas/">Etiquetas</a>
         </div>
-        <form class="search-form" action="/buscar/" method="get" role="search">
-          <label class="sr-only" for="site-search">Buscar</label>
-          <input id="site-search" type="search" name="q" placeholder="Buscar…" autocomplete="off">
-          <button type="submit" aria-label="Buscar">⌕</button>
-        </form>
+        <div class="utility-actions">
+          <form class="search-form" action="/buscar/" method="get" role="search">
+            <label class="sr-only" for="site-search">Buscar</label>
+            <input id="site-search" type="search" name="q" placeholder="Buscar…" autocomplete="off">
+            <button type="submit" aria-label="Buscar">⌕</button>
+          </form>
+          <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">
+            <span class="theme-toggle-icon" data-theme-icon aria-hidden="true">☾</span>
+            <span class="theme-toggle-label" data-theme-label>Modo oscuro</span>
+          </button>
+        </div>
       </div>
 
       <header class="masthead">


### PR DESCRIPTION
Resuelve #16.

Qué cambia:
- agrega un toggle visible en el header para alternar entre claro y oscuro
- persiste la preferencia del usuario en `localStorage`
- aplica el tema antes de cargar estilos para evitar flash de color incorrecto
- define una paleta oscura ajustada al tono editorial del sitio

Verificación:
- `npm run build`
