### PR TITLE
fix: lenguaje inclusivo en navegación y secciones

### DIFF
--- a/templates/authors_index.html
+++ b/templates/authors_index.html
@@ -1,13 +1,13 @@
 {% extends "base.html" %}
 
-{% block title %}Autores · {{ config.title }}{% endblock title %}
+{% block title %}Autoras y autores · {{ config.title }}{% endblock title %}
 
 {% block content %}
   <main class="pt-8">
     <section class="editorial-rule">
-      <span class="section-ribbon">Autores</span>
+      <span class="section-ribbon">Autoras y autores</span>
       <div class="mt-5 max-w-[48rem]">
-        <h2 class="story-title">Autores</h2>
+        <h2 class="story-title">Autoras y autores</h2>
       </div>
     </section>
 
@@ -20,7 +20,7 @@
                 <img src="{{ page.extra.image }}" alt="{{ page.title }}" loading="lazy">
               </a>
             {% endif %}
-            <p class="story-kicker">Autor</p>
+            <p class="story-kicker">Autora / Autor</p>
             <h2 class="story-title-xs"><a href="{{ page.permalink }}">{{ page.title }}</a></h2>
             <p class="mt-4 text-base leading-7 text-neutral-700">{{ page.extra.article_paths | length }} {% if page.extra.article_paths | length == 1 %}texto{% else %}textos{% endif %}</p>
           </article>

--- a/templates/base.html
+++ b/templates/base.html
@@ -15,7 +15,7 @@
       <div class="utility-bar">
         <div class="utility-links">
           <span>Martín Gaitán</span>
-          <a href="/autores/">Autores</a>
+          <a href="/autores/">Autoras y autores</a>
           <a href="/etiquetas/">Etiquetas</a>
         </div>
         <form class="search-form" action="/buscar/" method="get" role="search">
@@ -41,7 +41,7 @@
             <a class="nav-link" href="/">Inicio</a>
             <a class="nav-link" href="/blog/">Blog</a>
             <a class="nav-link" href="/fotos/">Fotos</a>
-            <a class="nav-link" href="/de-otros/">De otros</a>
+            <a class="nav-link" href="/de-otros/">De otres</a>
             <a class="nav-link" href="/videos/">Videos</a>
             <a class="nav-link" href="/random/" rel="nofollow" title="Llevame a un texto al azar">Aleatorio</a>
           </div>
@@ -55,10 +55,10 @@
             <a class="nav-link" href="/">Inicio</a>
             <a class="nav-link" href="/blog/">Blog</a>
             <a class="nav-link" href="/fotos/">Fotos</a>
-            <a class="nav-link" href="/de-otros/">De otros</a>
+            <a class="nav-link" href="/de-otros/">De otres</a>
             <a class="nav-link" href="/videos/">Videos</a>
             <a class="nav-link" href="/random/" rel="nofollow">Aleatorio</a>
-            <a class="nav-link" href="/autores/">Autores</a>
+            <a class="nav-link" href="/autores/">Autoras y autores</a>
             <a class="nav-link" href="/etiquetas/">Etiquetas</a>
           </div>
         </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -62,7 +62,7 @@
         {% if latest_other %}
           <div class="sidebar-block">
             <div class="mb-4">
-              <span class="section-ribbon">De otros</span>
+              <span class="section-ribbon">De otres</span>
             </div>
             {{ macros::story_card(page=latest_other, variant="compact") }}
           </div>


### PR DESCRIPTION
## Cambios

- **Nav principal y mobile**: "De otros" → "De otres", "Autores" → "Autoras y autores"
- **Utility bar**: "Autores" → "Autoras y autores"
- **Home ribbon**: "De otros" → "De otres"
- **Página de autoras y autores**: título y ribbon actualizados; kicker individual "Autor" → "Autora / Autor"

Las URLs `/de-otros/` y `/autores/` no cambian.

Fixes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)