### PR TITLE
fix: implementar issues 61 64 67

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,4 +89,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy public --project-name=textosypretextos --branch=main
+          command: pages deploy public --project-name=textosypretextos --branch=main --commit-dirty=true

--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -6,6 +6,7 @@ const navToggle = document.querySelector("[data-nav-toggle]");
 const navPanel = document.querySelector("[data-nav-panel]");
 const themeToggle = document.querySelector("[data-theme-toggle]");
 const THEME_STORAGE_KEY = "typ:theme";
+const COMMENTER_STORAGE_KEY = "typ:commenter";
 
 function resolveThemePreference() {
   const saved = root.dataset.theme;
@@ -350,6 +351,21 @@ function bindRecentCommentsRefresh(container) {
 
 function bindCommentForm(form, dynamicContainer, slug) {
   const status = form.querySelector("[data-status]");
+  const authorInput = form.querySelector('input[name="author"]');
+  const emailInput = form.querySelector('input[name="email"]');
+
+  try {
+    const saved = JSON.parse(localStorage.getItem(COMMENTER_STORAGE_KEY) || "{}");
+    if (authorInput && typeof saved.author === "string") {
+      authorInput.value = saved.author.slice(0, 80);
+    }
+    if (emailInput && typeof saved.email === "string") {
+      emailInput.value = saved.email.slice(0, 120);
+    }
+  } catch (_e) {
+    // Ignore storage failures.
+  }
+
   form.addEventListener("submit", async (e) => {
     e.preventDefault();
     const data = new FormData(form);
@@ -376,7 +392,21 @@ function bindCommentForm(form, dynamicContainer, slug) {
       }
       status.textContent = "¡Gracias! Tu comentario fue publicado.";
       status.dataset.state = "ok";
+      try {
+        localStorage.setItem(COMMENTER_STORAGE_KEY, JSON.stringify({
+          author: String(payload.author || "").slice(0, 80),
+          email: String(payload.email || "").slice(0, 120),
+        }));
+      } catch (_e) {
+        // Ignore persistence failures.
+      }
       form.reset();
+      if (authorInput) {
+        authorInput.value = String(payload.author || "").slice(0, 80);
+      }
+      if (emailInput) {
+        emailInput.value = String(payload.email || "").slice(0, 120);
+      }
       await loadDynamicComments(dynamicContainer, slug);
       announceRecentCommentRefresh();
     } catch (_e) {

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -281,6 +281,23 @@
     @apply border-b border-black py-4 last:border-b-0;
   }
 
+  .home-recent-comments {
+    @apply pb-2;
+  }
+
+  .home-comments-grid {
+    @apply grid border-y border-black;
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+  }
+
+  .home-comments-grid .comment-snippet {
+    @apply border-b border-black px-0 py-5;
+  }
+
+  .home-comments-grid .comment-snippet:last-child {
+    @apply border-b-0;
+  }
+
   .page-grid {
     @apply grid gap-10 lg:grid-cols-[minmax(0,1fr)_320px];
   }
@@ -699,6 +716,10 @@
     @apply min-w-0 lg:border-l lg:border-black lg:pl-10;
   }
 
+  .home-comments-grid {
+    @apply mt-0;
+  }
+
   .home-lead {
     @apply pb-10;
   }
@@ -718,6 +739,38 @@
 
   .home-blog-rest .home-listing-card {
     @apply border-b border-neutral-300 last:border-b-0;
+  }
+
+  @media (min-width: 768px) {
+    .home-comments-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .home-comments-grid .comment-snippet {
+      @apply border-b border-r border-black px-4;
+    }
+
+    .home-comments-grid .comment-snippet:nth-child(2n) {
+      @apply border-r-0;
+    }
+  }
+
+  @media (min-width: 1280px) {
+    .home-comments-grid {
+      grid-template-columns: repeat(5, minmax(0, 1fr));
+    }
+
+    .home-comments-grid .comment-snippet {
+      @apply min-h-[15rem] border-b-0 border-r border-black px-5;
+    }
+
+    .home-comments-grid .comment-snippet:nth-child(2n) {
+      @apply border-r border-black;
+    }
+
+    .home-comments-grid .comment-snippet:last-child {
+      @apply border-r-0;
+    }
   }
 
   .sidebar-block {

--- a/templates/index.html
+++ b/templates/index.html
@@ -85,22 +85,25 @@
           </div>
         </div>
 
-        <div class="sidebar-block">
-          <h2 class="module-title">Comentarios recientes</h2>
-          <div class="comment-stack" data-recent-comments>
-            {% for item in section.extra.recent_comments | slice(end=5) %}
-              {% set comment_page = get_page(path=item.article_path) %}
-              <article class="comment-snippet">
-                <p class="story-kicker">{{ item.author | default(value="Anónimo") }} · {{ item.date_display }}</p>
-                <h3 class="story-title-xs">
-                  <a href="{{ comment_page.permalink }}#{{ item.anchor }}">{{ comment_page.title }}</a>
-                </h3>
-                <p class="mt-2 text-sm leading-6 text-neutral-700">{{ item.excerpt }}</p>
-              </article>
-            {% endfor %}
-          </div>
-        </div>
       </aside>
     </div>
+
+    <section class="home-recent-comments editorial-rule mt-12">
+      <div class="mb-5">
+        <h2 class="module-title mb-0">Comentarios recientes</h2>
+      </div>
+      <div class="home-comments-grid" data-recent-comments>
+        {% for item in section.extra.recent_comments | slice(end=5) %}
+          {% set comment_page = get_page(path=item.article_path) %}
+          <article class="comment-snippet">
+            <p class="story-kicker">{{ item.author | default(value="Anónimo") }} · {{ item.date_display }}</p>
+            <h3 class="story-title-xs">
+              <a href="{{ comment_page.permalink }}#{{ item.anchor }}">{{ comment_page.title }}</a>
+            </h3>
+            <p class="mt-2 text-sm leading-6 text-neutral-700">{{ item.excerpt }}</p>
+          </article>
+        {% endfor %}
+      </div>
+    </section>
   </main>
 {% endblock content %}


### PR DESCRIPTION
Implementa en una sola rama los issues #61, #64 y #67.

Incluye:
- `#61`: agrega `--commit-dirty=true` al deploy con Wrangler para eliminar el warning en CI
- `#64`: mueve "Comentarios recientes" a un bloque horizontal full-width en home, con 5 columnas en desktop
- `#67`: persiste nombre y email del formulario de comentarios para reutilizarlos en envíos futuros

Validación:
- `npm run build`

Closes #61
Closes #64
Closes #67
