### PR TITLE
fix: eliminar línea vertical del sidebar en home (#183)

### DIFF
--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -722,7 +722,11 @@
   }
 
   .home-sidebar {
-    @apply min-w-0 lg:pl-10;
+    @apply min-w-0 lg:border-l lg:border-black lg:pl-10;
+  }
+
+  .home-sidebar .media-frame {
+    border: 0;
   }
 
   .home-comments-grid {

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -722,7 +722,7 @@
   }
 
   .home-sidebar {
-    @apply min-w-0 lg:border-l lg:border-black lg:pl-10;
+    @apply min-w-0 lg:pl-10;
   }
 
   .home-comments-grid {

--- a/templates/article.html
+++ b/templates/article.html
@@ -28,7 +28,7 @@
       {% endif %}
       <div class="meta-row">
         <span>{{ page.date | date(format="%d.%m.%Y") }}</span>
-        {% if page.extra.comment_count > 0 %}
+        {% if page.extra.comment_count | default(value=0) > 0 %}
           <a href="#comments" class="meta-link">{{ page.extra.comment_count }} comentarios</a>
         {% endif %}
       </div>

--- a/templates/partials/macros.html
+++ b/templates/partials/macros.html
@@ -63,7 +63,7 @@
             {% endfor %}
           </span>
         {% endif %}
-        {% if page.extra.comment_count > 0 %}
+        {% if page.extra.comment_count | default(value=0) > 0 %}
           <span>{{ page.extra.comment_count }} comentarios</span>
         {% endif %}
       </div>


### PR DESCRIPTION
## Summary

- Quita `lg:border-l lg:border-black` de `.home-sidebar` — la foto del sidebar ya tiene borde en los 4 lados via `.media-frame`, el `border-l` del sidebar generaba una línea vertical extra
- Corrige build failure: agrega `| default(value=0)` a `page.extra.comment_count` en `article.html` y `macros.html` para no crashear cuando un artículo omite el campo (regresión introducida por el contenido de `el-oso.md` en PR #176)

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)