### PR TITLE
fix: 5 comentarios en home con enfoque híbrido D1 + estáticos (#186)

### DIFF
--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -252,7 +252,7 @@ async function loadRecentComments(container) {
     if (!comments.length) return;
 
     const { bySlug } = buildArticleIndexes(docs);
-    const html = comments
+    const dynamicParts = comments
       .map((comment) => {
         const article = bySlug.get(comment.article_slug);
         if (!article) return "";
@@ -267,11 +267,13 @@ async function loadRecentComments(container) {
           </article>
         `;
       })
-      .filter(Boolean)
-      .join("");
-    if (html) {
-      container.innerHTML = html;
-    }
+      .filter(Boolean);
+    if (!dynamicParts.length) return;
+    const needed = Math.max(0, 5 - dynamicParts.length);
+    const staticFallback = Array.from(container.querySelectorAll("article.comment-snippet"))
+      .slice(0, needed)
+      .map((el) => el.outerHTML);
+    container.innerHTML = [...dynamicParts, ...staticFallback].join("");
   } catch (_e) {
     // Keep the static fallback if dynamic loading fails.
   }


### PR DESCRIPTION
## Summary

- Si D1 devuelve menos de 5 comentarios recientes, completa los slots restantes con los comentarios históricos que ya están renderizados en el HTML como fallback estático
- Sin cambios en templates ni JSON incrustado: lee los `article.comment-snippet` existentes en el DOM antes de reemplazar el container
- Los comentarios de D1 aparecen primero (más recientes), seguidos por los históricos

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)