### PR TITLE
feat: sistematizar normalización de diálogos (#191)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,20 @@ uv run scripts/fix_dialogues.py --apply content/fotos/cronica-de-un-intento-de-h
 
 - Sin `--apply`, el script corre en modo dry-run e informa candidatos y casos ambiguos para revisión manual.
 
+### Poesía
+
+- Para poesía o texto con cortes de verso que haya que preservar, envolver el bloque con `<div class="poetry">`:
+
+```md
+<div class="poetry">
+Primer verso
+Segundo verso
+Tercer verso
+</div>
+```
+
+- No usar `<br>` para simular versos si el bloque completo puede resolverse con `poetry`.
+
 ### Ortografía
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,25 @@ Audio/archivos:
 
 - Reusar los shortcodes de `templates/shortcodes/`.
 
+### Diálogos
+
+- Para bloques de diálogo con una intervención por línea, usar la macro `dialogo` en vez de `<br>` manuales:
+
+```md
+{% dialogo() %}
+— Primera intervención
+— Segunda intervención
+{% end %}
+```
+
+- Para detectar y corregir casos simples con `--`, usar:
+
+```bash
+uv run scripts/fix_dialogues.py --apply content/fotos/cronica-de-un-intento-de-homenaje.md
+```
+
+- Sin `--apply`, el script corre en modo dry-run e informa candidatos y casos ambiguos para revisión manual.
+
 ### Ortografía
 
 ```bash

--- a/content/blog/relato-de-un-narrador.md
+++ b/content/blog/relato-de-un-narrador.md
@@ -82,22 +82,15 @@ Y no llegaba y no llegaba, y nosotros pensamos que nos estaba asustando, o algo 
 
 Nosotros, lo único que teníamos que hacer era que cuando le iban a pegar a mi amigo, yo tenía que mirar nomás, y después él me miraba a mi cómo me pegaban. Y hasta que gozó, todo de pegarnos. Se cansó de pegarnos así, y agarró y mandó a los otros para arriba, para el cerro, porque supuestamente andaban tres ahí, en ese campo. Y él se quedó con nosotros, él y el hijo más chico, creo, no sé cuantos años tendrá, uno chiquitito así, debe tener como trece o catorce años. Y ahí nos empezó a huevear así, nos sacaron los reloj, todo. Nos sacó los reloj, las cadenitas así. Nosotros teníamos...teníamos unos hilos acá en el cuello, teníamos colgantes, y nos decían que nos saquemos esos porque parecíamos putos. Y nosotros no podíamos densatar los nudos, por ahí algunos que tenían, y los arrancaba así de un tirón, así ¡pá!. 
 
--- Del que estás hablando es Del Campo el apellido, ¿no?
-
--- Sí. 
-
--- Él qué creía, ¿que ustedes le estaban robando?
-
--- Claro porque nos decía chorros, de todo nos decía. 
-
--- ¿Y cómo termina todo allí?
-
--- ¿Qué?
-
--- ¿Cómo termina? ¿Pueden escapar? ¿Los libera?
-
--- No, después nos agarró de los pelos así, nos empezaba a tirar así y a decir que digamos que eramos trolos, putos, así, después se cansó de decirnos y dijo "bueno, vamos a hacer un trato" dijo, "ustedes se van por este cañadoncito, siempre mirando para la ruta" dijo, "y se quedan escondidos en aquel arbolito. Cuando pase el Ko-kó, el colectivo, no suban a la ruta, porque yo mandé a poner un policía. Después cuando pase, ahí salen ustedes y hacen dedo. Y si ven la policía ustedes dicen que no estaban en el campo, y que yo no los golpié, o sino yo a ustede los voy a meter preso no sé por cuanto" dijo. Nos dijo que era algo de rural, jefe rural, así. 
-
--- ¿Y qué hicieron ahí?
-
--- Y nosotros seguíamos nomás para allá, y de repente vimos que venía él, atrás en la camioneta y nosotros con amigo decíamos "para dónde disparamos" porque pensamos que nos iban a pegar ahí. Y nos quedamos, y viene así, y venía un policía. Y decimos "uh, estamos salvados", era como que habían llegado nuestro padre o alguien así que ya sabíamos que nos nos iban a pegar más. Y se bajó así, re caliente así Don Mario. Y agarró y dijo "¿por qué me mentiste?" dijo, "¿por qué no me dijiste que eras hijo de ese chorro, hijo de..,  el milico de la camioneta marrón", dijo, porque mi papá tiene una camioneta marrón con la que vamos a pescar. Y lo puteó de arriba a abajo así, y yo lo miraba al policía a ver si decía algo. Pero era un oficial y no decía nada, y agachó la cabeza así, y cambió de tema enseguida, y dijo "bueno vamos", y me indica dónde bajaban los otros. Cuando veníamos en el colectivo bajaron antes ellos. Eran tres. Y nosotros seguímos nomás.
+{% dialogo() %}
+— Del que estás hablando es Del Campo el apellido, ¿no?
+— Sí.
+— Él qué creía, ¿que ustedes le estaban robando?
+— Claro porque nos decía chorros, de todo nos decía.
+— ¿Y cómo termina todo allí?
+— ¿Qué?
+— ¿Cómo termina? ¿Pueden escapar? ¿Los libera?
+— No, después nos agarró de los pelos así, nos empezaba a tirar así y a decir que digamos que eramos trolos, putos, así, después se cansó de decirnos y dijo "bueno, vamos a hacer un trato" dijo, "ustedes se van por este cañadoncito, siempre mirando para la ruta" dijo, "y se quedan escondidos en aquel arbolito. Cuando pase el Ko-kó, el colectivo, no suban a la ruta, porque yo mandé a poner un policía. Después cuando pase, ahí salen ustedes y hacen dedo. Y si ven la policía ustedes dicen que no estaban en el campo, y que yo no los golpié, o sino yo a ustede los voy a meter preso no sé por cuanto" dijo. Nos dijo que era algo de rural, jefe rural, así.
+— ¿Y qué hicieron ahí?
+— Y nosotros seguíamos nomás para allá, y de repente vimos que venía él, atrás en la camioneta y nosotros con amigo decíamos "para dónde disparamos" porque pensamos que nos iban a pegar ahí. Y nos quedamos, y viene así, y venía un policía. Y decimos "uh, estamos salvados", era como que habían llegado nuestro padre o alguien así que ya sabíamos que nos nos iban a pegar más. Y se bajó así, re caliente así Don Mario. Y agarró y dijo "¿por qué me mentiste?" dijo, "¿por qué no me dijiste que eras hijo de ese chorro, hijo de..,  el milico de la camioneta marrón", dijo, porque mi papá tiene una camioneta marrón con la que vamos a pescar. Y lo puteó de arriba a abajo así, y yo lo miraba al policía a ver si decía algo. Pero era un oficial y no decía nada, y agachó la cabeza así, y cambió de tema enseguida, y dijo "bueno vamos", y me indica dónde bajaban los otros. Cuando veníamos en el colectivo bajaron antes ellos. Eran tres. Y nosotros seguímos nomás.
+{% end %}

--- a/content/fotos/cronica-de-un-intento-de-homenaje.md
+++ b/content/fotos/cronica-de-un-intento-de-homenaje.md
@@ -54,9 +54,11 @@ body = "Estaba rebuscando este antsuo en particular mediante el uso de ask cuand
 
 Muchas de estas fotos logré sacarlar gracias al descubrimiento de mi amigo y compañero Leandro y a la aparaciencia profesional (para el que no tiene mucha idea) de mi cámara de fotos. 
 
--- *Tincho, mirá, ahí están acreditando a la prensa* -- anotició Lea, y yo enfilé para la cola. 
--- *Hola, acabo de llegar de Neuquén, cubro para el periódico [8300](http://www.8300.com.ar). * -- indiqué a la chica con total convicción. 
--- A ver, dejame buscar... -- contestó totalmente desbordada por la situación, la acreditadora -- Bueno, pasá. 
+{% dialogo() %}
+— *Tincho, mirá, ahí están acreditando a la prensa* -- anotició Lea, y yo enfilé para la cola.
+— *Hola, acabo de llegar de Neuquén, cubro para el periódico [8300](http://www.8300.com.ar). * -- indiqué a la chica con total convicción.
+— A ver, dejame buscar... -- contestó totalmente desbordada por la situación, la acreditadora -- Bueno, pasá.
+{% end %}
 
 Fácil. Ja. 
 

--- a/scripts/fix_dialogues.py
+++ b/scripts/fix_dialogues.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env -S uv run python
+# /// script
+# requires-python = ">=3.11"
+# ///
+"""Normalize obvious dialogue blocks in markdown content.
+
+Conservative by design:
+- only rewrites blocks with 2+ dialogue lines starting with `--`
+- skips files that already use the `dialogo` shortcode for that block
+- reports single/ambiguous candidates for manual review
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+from dataclasses import dataclass
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+CONTENT = ROOT / "content"
+
+RE_FRONTMATTER = re.compile(r"^\+\+\+\n.*?\n\+\+\+\n?", re.DOTALL)
+RE_DIALOGUE_START = re.compile(r"^(\s*)--(?!-)(.*\S)?\s*$")
+RE_DIALOGUE_IGNORE = re.compile(r"^\s*--+\s*$|^\s*--o--\s*$", re.IGNORECASE)
+RE_DIALOGUE_SHORTCODE_START = re.compile(r"^\s*\{%\s*dialogo\(\)\s*%\}\s*$")
+RE_DIALOGUE_SHORTCODE_END = re.compile(r"^\s*\{%\s*end\s*%\}\s*$")
+
+
+@dataclass
+class Block:
+    start: int
+    end: int
+    lines: list[str]
+
+
+def split_frontmatter(text: str) -> tuple[str, str]:
+    match = RE_FRONTMATTER.match(text)
+    if not match:
+        return "", text
+    return match.group(0), text[match.end() :]
+
+
+def is_dialogue_line(line: str) -> bool:
+    if RE_DIALOGUE_IGNORE.match(line):
+        return False
+    match = RE_DIALOGUE_START.match(line)
+    if not match:
+        return False
+    rest = (match.group(2) or "").strip()
+    return bool(rest)
+
+
+def normalize_dialogue_line(line: str) -> str:
+    match = RE_DIALOGUE_START.match(line)
+    if not match:
+        return line.rstrip()
+    indent = match.group(1)
+    rest = (match.group(2) or "").strip()
+    return f"{indent}— {rest}".rstrip()
+
+
+def find_blocks(lines: list[str]) -> tuple[list[Block], list[int]]:
+    blocks: list[Block] = []
+    ambiguous: list[int] = []
+    in_shortcode = False
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if RE_DIALOGUE_SHORTCODE_START.match(line):
+            in_shortcode = True
+            i += 1
+            continue
+        if in_shortcode:
+            if RE_DIALOGUE_SHORTCODE_END.match(line):
+                in_shortcode = False
+            i += 1
+            continue
+        if not is_dialogue_line(line):
+            i += 1
+            continue
+
+        start = i
+        candidate_indexes: list[int] = []
+        j = i
+        while j < len(lines):
+            current = lines[j]
+            if is_dialogue_line(current):
+                candidate_indexes.append(j)
+                j += 1
+                continue
+            if current.strip() == "":
+                j += 1
+                continue
+            break
+
+        if len(candidate_indexes) >= 2:
+            block_lines = [normalize_dialogue_line(lines[idx]) for idx in candidate_indexes]
+            blocks.append(Block(start=start, end=j, lines=block_lines))
+        else:
+            ambiguous.extend(candidate_indexes)
+        i = j
+    return blocks, ambiguous
+
+
+def apply_blocks(lines: list[str], blocks: list[Block]) -> list[str]:
+    if not blocks:
+        return lines[:]
+    out: list[str] = []
+    cursor = 0
+    for block in blocks:
+        out.extend(lines[cursor:block.start])
+        if out and out[-1].strip():
+            out.append("")
+        out.append("{% dialogo() %}")
+        out.extend(block.lines)
+        out.append("{% end %}")
+        if block.end < len(lines) and lines[block.end].strip():
+            out.append("")
+        cursor = block.end
+    out.extend(lines[cursor:])
+    return out
+
+
+def process_file(path: pathlib.Path, apply: bool) -> tuple[int, int]:
+    text = path.read_text(encoding="utf-8")
+    frontmatter, body = split_frontmatter(text)
+    lines = body.splitlines()
+    blocks, ambiguous = find_blocks(lines)
+
+    rel = path.relative_to(ROOT)
+    if not blocks and not ambiguous:
+        return 0, 0
+
+    if blocks:
+        ranges = ", ".join(f"{b.start + 1}-{b.end}" for b in blocks)
+        print(f"{rel}: {len(blocks)} bloque(s) candidatos en líneas {ranges}")
+    if ambiguous:
+        joined = ", ".join(str(n + 1) for n in ambiguous[:10])
+        suffix = "…" if len(ambiguous) > 10 else ""
+        print(f"{rel}: {len(ambiguous)} línea(s) ambiguas para revisión manual ({joined}{suffix})")
+
+    if apply and blocks:
+        new_body = "\n".join(apply_blocks(lines, blocks))
+        if body.endswith("\n"):
+            new_body += "\n"
+        path.write_text(frontmatter + new_body, encoding="utf-8")
+    return len(blocks), len(ambiguous)
+
+
+def resolve_paths(args: list[str]) -> list[pathlib.Path]:
+    if args:
+        return [pathlib.Path(arg).resolve() for arg in args]
+    return sorted(CONTENT.rglob("*.md"))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="*", help="Archivos a revisar (default: content/**/*.md)")
+    parser.add_argument("--apply", action="store_true", help="Escribir cambios en los archivos")
+    opts = parser.parse_args()
+
+    paths = [path for path in resolve_paths(opts.paths) if path.exists() and path.suffix == ".md"]
+    total_blocks = 0
+    total_ambiguous = 0
+    for path in paths:
+        blocks, ambiguous = process_file(path, apply=opts.apply)
+        total_blocks += blocks
+        total_ambiguous += ambiguous
+
+    mode = "apply" if opts.apply else "dry-run"
+    print(
+        f"\nResumen ({mode}): {total_blocks} bloque(s) candidatos, "
+        f"{total_ambiguous} línea(s) ambiguas."
+    )
+    if total_ambiguous:
+        print("Revisá manualmente los casos ambiguos antes de asumir que todo quedó listo.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #191

## Qué cambia
- agrega `scripts/fix_dialogues.py` para detectar y normalizar bloques de diálogo con `--`
- soporta `dry-run` por defecto y `--apply` para escribir cambios
- convierte el arranque de parlamentos a raya `—` y envuelve bloques consecutivos con `{% dialogo() %}`
- reporta líneas ambiguas para revisión manual
- documenta el flujo en `AGENTS.md`
- aplica la herramienta a dos casos claros del corpus

## Validación
- `uv run scripts/fix_dialogues.py`
- `uv run scripts/fix_dialogues.py content/fotos/cronica-de-un-intento-de-homenaje.md`
- `uv run scripts/fix_dialogues.py content/blog/relato-de-un-narrador.md`
- `npm run build`
