### PR TITLE
fix: De otres en sidebar muestra el más reciente dinámicamente (#204)

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -9,7 +9,8 @@
   {% set featured_photo = fotos_section.pages | first %}
   {% set videos_section = get_section(path="videos/_index.md") %}
   {% set latest_video = videos_section.pages | first %}
-  {% set latest_other = get_page(path=section.extra.latest_other_path) %}
+  {% set de_otros_section = get_section(path="de-otros/_index.md") %}
+  {% set latest_other = de_otros_section.pages | first %}
   {% set blog_pages = blog.pages | slice(end=8) %}
 
   <main class="pt-8">


### PR DESCRIPTION
## Problema

El bloque "De otres" del sidebar usaba un path hardcodeado en `_index.md` (`latest_other_path`), por lo que siempre mostraba el mismo artículo sin importar qué se publicara después.

## Solución

Reemplaza `get_page(path=section.extra.latest_other_path)` por `get_section("de-otros/_index.md").pages | first`, igual que ya se hace con `featured_photo` y `latest_video`.

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)