### PR TITLE
fix: facade YouTube para videos y alineación masthead (#205 #206)

### DIFF
--- a/content/videos/1-ano-sin-carlos-y-sin-justicia.md
+++ b/content/videos/1-ano-sin-carlos-y-sin-justicia.md
@@ -16,6 +16,7 @@ tags = [
 ]
 
 [extra]
+video_id = "g91cOZkXtSo"
 legacy_id = 101
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/a-traves-de-tus-ojos.md
+++ b/content/videos/a-traves-de-tus-ojos.md
@@ -18,6 +18,7 @@ tags = [
 ]
 
 [extra]
+video_id = "8Xl5ZaInIc8"
 legacy_id = 0
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/big-buck-bunny.md
+++ b/content/videos/big-buck-bunny.md
@@ -17,6 +17,7 @@ tags = [
 ]
 
 [extra]
+video_id = "YE7VzlLtp-4"
 legacy_id = 143
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/big-google.md
+++ b/content/videos/big-google.md
@@ -14,6 +14,7 @@ categories = [
 tags = []
 
 [extra]
+video_id = "fPgV6-gnQaE"
 legacy_id = 135
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/campo-afuera.md
+++ b/content/videos/campo-afuera.md
@@ -14,6 +14,7 @@ categories = [
 tags = []
 
 [extra]
+video_id = "cNYQ0vTFeHk"
 legacy_id = 313
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/carta-desde-beirut.md
+++ b/content/videos/carta-desde-beirut.md
@@ -14,6 +14,7 @@ categories = [
 tags = []
 
 [extra]
+video_id = "lWmQEaA6OKI"
 legacy_id = 265
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/cartas-al-rey-de-la-cabina.md
+++ b/content/videos/cartas-al-rey-de-la-cabina.md
@@ -17,6 +17,7 @@ tags = [
 ]
 
 [extra]
+video_id = "W0UEct25rpU"
 legacy_id = 399
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/closet.md
+++ b/content/videos/closet.md
@@ -14,6 +14,7 @@ categories = [
 tags = []
 
 [extra]
+video_id = "B1hOjyQkgao"
 legacy_id = 145
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/cruz-del-sur.md
+++ b/content/videos/cruz-del-sur.md
@@ -14,6 +14,7 @@ categories = [
 tags = []
 
 [extra]
+video_id = "j4s6T1J_3pY"
 legacy_id = 127
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/discurso-de-pepe-mujica-en-rio-20.md
+++ b/content/videos/discurso-de-pepe-mujica-en-rio-20.md
@@ -17,6 +17,7 @@ tags = [
 ]
 
 [extra]
+video_id = "wl2nMudbSm8"
 legacy_id = 432
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/el-beso.md
+++ b/content/videos/el-beso.md
@@ -17,6 +17,7 @@ tags = [
 ]
 
 [extra]
+video_id = "mb4WoMgVxFQ"
 legacy_id = 311
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/el-chiste-mas-gracioso-del-mundo.md
+++ b/content/videos/el-chiste-mas-gracioso-del-mundo.md
@@ -16,6 +16,7 @@ tags = [
 ]
 
 [extra]
+video_id = "F7oTJsdLsJg"
 legacy_id = 255
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/el-conflicto-boliviano.md
+++ b/content/videos/el-conflicto-boliviano.md
@@ -14,6 +14,7 @@ categories = [
 tags = []
 
 [extra]
+video_id = "9VKZfWzRue0"
 legacy_id = 230
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/el-libertador.md
+++ b/content/videos/el-libertador.md
@@ -14,6 +14,7 @@ categories = [
 tags = []
 
 [extra]
+video_id = "Du7sbLC9stI"
 legacy_id = 242
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/el-perro-negro.md
+++ b/content/videos/el-perro-negro.md
@@ -17,6 +17,7 @@ tags = [
 ]
 
 [extra]
+video_id = "-QB6EsHAih8"
 legacy_id = 110
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/el-umbral.md
+++ b/content/videos/el-umbral.md
@@ -16,6 +16,7 @@ tags = [
 ]
 
 [extra]
+video_id = "39DnBGPApZc"
 legacy_id = 434
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/elvira.md
+++ b/content/videos/elvira.md
@@ -17,6 +17,7 @@ tags = [
 ]
 
 [extra]
+video_id = "AhfUfjLpNvI"
 legacy_id = 342
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/esa-costumbre-de-matar.md
+++ b/content/videos/esa-costumbre-de-matar.md
@@ -16,6 +16,7 @@ tags = [
 ]
 
 [extra]
+video_id = "OJOFeXO2mpE"
 legacy_id = 95
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/eureka.md
+++ b/content/videos/eureka.md
@@ -20,6 +20,7 @@ tags = [
 ]
 
 [extra]
+video_id = "PVkSg7S4n58"
 legacy_id = 372
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/fico-assim-sem-voce.md
+++ b/content/videos/fico-assim-sem-voce.md
@@ -16,6 +16,7 @@ tags = [
 ]
 
 [extra]
+video_id = "Qjp_udjoUD4"
 legacy_id = 194
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/foutaises.md
+++ b/content/videos/foutaises.md
@@ -17,6 +17,7 @@ tags = [
 ]
 
 [extra]
+video_id = "KzSutnFrI6I"
 legacy_id = 202
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/game-called-life.md
+++ b/content/videos/game-called-life.md
@@ -14,6 +14,7 @@ categories = [
 tags = []
 
 [extra]
+video_id = "ZDHofTEYeoQ"
 legacy_id = 418
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/hasta-los-huesos.md
+++ b/content/videos/hasta-los-huesos.md
@@ -16,6 +16,7 @@ tags = [
 ]
 
 [extra]
+video_id = "aM6sP61zNx4"
 legacy_id = 186
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/hey-you-pink-floyd.md
+++ b/content/videos/hey-you-pink-floyd.md
@@ -14,6 +14,7 @@ categories = [
 tags = []
 
 [extra]
+video_id = "lRcQZ2tnWeg"
 legacy_id = 100
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/hoy-es-un-dia-historico.md
+++ b/content/videos/hoy-es-un-dia-historico.md
@@ -14,6 +14,7 @@ categories = [
 tags = []
 
 [extra]
+video_id = "HG18kguB2zY"
 legacy_id = 228
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/imposibl-es-nating.md
+++ b/content/videos/imposibl-es-nating.md
@@ -17,6 +17,7 @@ tags = [
 ]
 
 [extra]
+video_id = "R5HUQAb_vik"
 legacy_id = 161
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/kaffe.md
+++ b/content/videos/kaffe.md
@@ -14,6 +14,7 @@ categories = [
 tags = []
 
 [extra]
+video_id = "1bWG-cGsAXw"
 legacy_id = 334
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/kung-fu-2003.md
+++ b/content/videos/kung-fu-2003.md
@@ -17,6 +17,7 @@ tags = [
 ]
 
 [extra]
+video_id = "4oV5ZE5XVMI"
 legacy_id = 254
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/l-equip-petit.md
+++ b/content/videos/l-equip-petit.md
@@ -16,6 +16,7 @@ tags = [
 ]
 
 [extra]
+video_id = "TvLV5Iy6YDk"
 legacy_id = 380
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/la-dama-y-la-muerte.md
+++ b/content/videos/la-dama-y-la-muerte.md
@@ -17,6 +17,7 @@ tags = [
 ]
 
 [extra]
+video_id = "3dt47iqLBfU"
 legacy_id = 360
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/la-iguana-lila-downs.md
+++ b/content/videos/la-iguana-lila-downs.md
@@ -14,6 +14,7 @@ categories = [
 tags = []
 
 [extra]
+video_id = "Ww2EX0OdDeA"
 legacy_id = 92
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/la-isla-de-las-flores.md
+++ b/content/videos/la-isla-de-las-flores.md
@@ -14,6 +14,7 @@ categories = [
 tags = []
 
 [extra]
+video_id = "TIeU7_yqrpc"
 legacy_id = 149
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/la-policia-del-amor.md
+++ b/content/videos/la-policia-del-amor.md
@@ -17,6 +17,7 @@ tags = [
 ]
 
 [extra]
+video_id = "ottUxuObNUA"
 legacy_id = 362
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/la-soja-transgenica.md
+++ b/content/videos/la-soja-transgenica.md
@@ -14,6 +14,7 @@ categories = [
 tags = []
 
 [extra]
+video_id = "u6H-4iomX_U"
 legacy_id = 207
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/las-buenas-intenciones.md
+++ b/content/videos/las-buenas-intenciones.md
@@ -17,6 +17,7 @@ tags = [
 ]
 
 [extra]
+video_id = "ybWbNeQWK4Y"
 legacy_id = 175
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/lo-que-tu-quieras-oir.md
+++ b/content/videos/lo-que-tu-quieras-oir.md
@@ -17,6 +17,7 @@ tags = [
 ]
 
 [extra]
+video_id = "12Z3J1uzd0Q"
 legacy_id = 138
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/mamita-peyote.md
+++ b/content/videos/mamita-peyote.md
@@ -15,6 +15,7 @@ tags = [
 ]
 
 [extra]
+video_id = "wAVUYDCjov8"
 section_slug = "videos"
 section_title = "Videos"
 summary = "Sentencia, de Mamita Peyote, con músicos invitados de Bersuit Vergarabat y Los Auténticos Decadentes."

--- a/content/videos/masi-me-tiro.md
+++ b/content/videos/masi-me-tiro.md
@@ -17,6 +17,7 @@ tags = [
 ]
 
 [extra]
+video_id = "D9FQxiUtQ88"
 legacy_id = 346
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/my-name-is-lisa.md
+++ b/content/videos/my-name-is-lisa.md
@@ -16,6 +16,7 @@ tags = [
 ]
 
 [extra]
+video_id = "m58zutsI3GA"
 legacy_id = 156
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/no-se-preocupe.md
+++ b/content/videos/no-se-preocupe.md
@@ -14,6 +14,7 @@ categories = [
 tags = []
 
 [extra]
+video_id = "l8FV5sWkXsY"
 legacy_id = 336
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/nuestra-maravillosa-naturaleza.md
+++ b/content/videos/nuestra-maravillosa-naturaleza.md
@@ -16,6 +16,7 @@ tags = [
 ]
 
 [extra]
+video_id = "0aFKSvw4bjU"
 legacy_id = 306
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/nuevo-articulo.md
+++ b/content/videos/nuevo-articulo.md
@@ -14,6 +14,7 @@ categories = [
 tags = []
 
 [extra]
+video_id = "EnoNISwvtjs"
 legacy_id = 88
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/oktapodi.md
+++ b/content/videos/oktapodi.md
@@ -16,6 +16,7 @@ tags = [
 ]
 
 [extra]
+video_id = "XyuqtOuljSw"
 legacy_id = 296
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/padre-e-hija.md
+++ b/content/videos/padre-e-hija.md
@@ -16,6 +16,7 @@ tags = [
 ]
 
 [extra]
+video_id = "VUqBfBRYI4A"
 legacy_id = 106
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/pigeon-impossible.md
+++ b/content/videos/pigeon-impossible.md
@@ -17,6 +17,7 @@ tags = [
 ]
 
 [extra]
+video_id = "jEjUAnPc2VA"
 legacy_id = 348
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/presto.md
+++ b/content/videos/presto.md
@@ -16,6 +16,7 @@ tags = [
 ]
 
 [extra]
+video_id = "qp71kQZMRZM"
 legacy_id = 295
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/rafael-correa-gana-reeleccion.md
+++ b/content/videos/rafael-correa-gana-reeleccion.md
@@ -14,6 +14,7 @@ categories = [
 tags = []
 
 [extra]
+video_id = "UL4eBZrwldA"
 legacy_id = 312
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/resueltos-a-ser-libres.md
+++ b/content/videos/resueltos-a-ser-libres.md
@@ -16,6 +16,7 @@ tags = [
 ]
 
 [extra]
+video_id = "oASasGvWGQc"
 legacy_id = 223
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/richard-stallman-en-diputados.md
+++ b/content/videos/richard-stallman-en-diputados.md
@@ -17,6 +17,7 @@ tags = [
 ]
 
 [extra]
+video_id = "IGUjLIu2Hq0"
 legacy_id = 250
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/sentipensar-el-futbol.md
+++ b/content/videos/sentipensar-el-futbol.md
@@ -14,6 +14,7 @@ categories = [
 tags = []
 
 [extra]
+video_id = "sMV-2uZqIrw"
 legacy_id = 430
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/signs.md
+++ b/content/videos/signs.md
@@ -16,6 +16,7 @@ tags = [
 ]
 
 [extra]
+video_id = "uy0HNWto0UY"
 legacy_id = 293
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/soporte-tecnico.md
+++ b/content/videos/soporte-tecnico.md
@@ -14,6 +14,7 @@ categories = [
 tags = []
 
 [extra]
+video_id = "K654kfJy9ZA"
 legacy_id = 117
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/surprise-the-movie.md
+++ b/content/videos/surprise-the-movie.md
@@ -14,6 +14,7 @@ categories = [
 tags = []
 
 [extra]
+video_id = "ge7R19dH31o"
 legacy_id = 142
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/the-lunch-date.md
+++ b/content/videos/the-lunch-date.md
@@ -14,6 +14,7 @@ categories = [
 tags = []
 
 [extra]
+video_id = "epuTZigxUY8"
 legacy_id = 315
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/vincent.md
+++ b/content/videos/vincent.md
@@ -14,6 +14,7 @@ categories = [
 tags = []
 
 [extra]
+video_id = "ZH3R5ntFK3c"
 legacy_id = 131
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/vuelvan-a-tilcara.md
+++ b/content/videos/vuelvan-a-tilcara.md
@@ -14,6 +14,7 @@ categories = [
 tags = []
 
 [extra]
+video_id = "TPrr_TO0kWg"
 legacy_id = 445
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/whassup.md
+++ b/content/videos/whassup.md
@@ -16,6 +16,7 @@ tags = [
 ]
 
 [extra]
+video_id = "W16qzZ7J5YQ"
 legacy_id = 303
 section_slug = "videos"
 section_title = "Videos"

--- a/content/videos/zona-cerrada.md
+++ b/content/videos/zona-cerrada.md
@@ -17,6 +17,7 @@ tags = [
 ]
 
 [extra]
+video_id = "Hzqw7oBZT8k"
 legacy_id = 309
 section_slug = "videos"
 section_title = "Videos"

--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -469,3 +469,16 @@ const articleTracker = document.querySelector("[data-track-article-view]");
 if (articleTracker) {
   trackArticleView(articleTracker);
 }
+
+document.addEventListener("click", (e) => {
+  const btn = e.target.closest(".video-facade");
+  if (!btn) return;
+  const src = btn.dataset.src;
+  if (!src) return;
+  const iframe = document.createElement("iframe");
+  iframe.src = src;
+  iframe.allow = "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share";
+  iframe.allowFullscreen = true;
+  iframe.className = "w-full h-full border-0";
+  btn.replaceWith(iframe);
+});

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -123,6 +123,13 @@
     @apply pb-2 text-[3rem] leading-[0.9] tracking-[-0.04em] text-black sm:text-[4.8rem] lg:text-[6.5rem];
   }
 
+  @media (min-width: 1024px) {
+    .masthead .story-kicker {
+      margin-left: 2em;
+      margin-top: -0.6em;
+    }
+  }
+
   .brand-deck {
     font-family: var(--font-ui);
     @apply max-w-[34rem] text-sm leading-6 text-neutral-600;
@@ -224,6 +231,35 @@
 
   .media-frame.video iframe {
     @apply h-full w-full border-0;
+  }
+
+  .video-facade {
+    @apply block w-full h-full bg-cover bg-center bg-no-repeat border-0 cursor-pointer p-0;
+    position: relative;
+  }
+
+  .video-play-icon {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.3);
+    transition: background 0.2s;
+  }
+
+  .video-play-icon::after {
+    content: "";
+    width: 0;
+    height: 0;
+    border-style: solid;
+    border-width: 20px 0 20px 36px;
+    border-color: transparent transparent transparent white;
+    filter: drop-shadow(0 2px 4px rgba(0,0,0,0.5));
+  }
+
+  .video-facade:hover .video-play-icon {
+    background: rgba(0, 0, 0, 0.5);
   }
 
   .editorial-rule {

--- a/templates/partials/macros.html
+++ b/templates/partials/macros.html
@@ -22,6 +22,11 @@
       <a href="{{ page.permalink }}" class="media-frame {% if page.extra.section_slug == 'videos' %}video{% endif %} reveal {% if is_feature %}aspect-[16/10]{% elif is_list or is_home_list %}aspect-[4/3]{% else %}aspect-[16/9]{% endif %}">
         <img src="{{ page.extra.hero_image }}" alt="{{ page.extra.hero_alt | default(value=page.title) }}">
       </a>
+    {% elif page.extra.section_slug == "videos" and page.extra.video_id %}
+      <a href="{{ page.permalink }}" class="media-frame video reveal aspect-[16/9]">
+        <img src="https://img.youtube.com/vi/{{ page.extra.video_id }}/hqdefault.jpg"
+             alt="{{ page.title }}" loading="lazy">
+      </a>
     {% elif page.extra.section_slug == "videos" %}
       <a href="{{ page.permalink }}" class="media-frame video reveal flex items-center justify-center text-white">
         <span class="section-ribbon">Video</span>

--- a/templates/shortcodes/video_embed.html
+++ b/templates/shortcodes/video_embed.html
@@ -1,13 +1,11 @@
 <figure class="align-center">
-  <div class="media-frame video">
+  <div class="media-frame video aspect-[16/9]">
     {% if provider == "youtube" %}
-      <iframe
-        src="https://www.youtube.com/embed/{{ id }}"
-        title="{{ title | default(value="Video") }}"
-        loading="lazy"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-        allowfullscreen
-      ></iframe>
+      <button class="video-facade" data-src="https://www.youtube.com/embed/{{ id }}?autoplay=1"
+              style="background-image:url('https://img.youtube.com/vi/{{ id }}/hqdefault.jpg')"
+              aria-label="{{ title | default(value='Reproducir video') }} — {{ title | default(value='YouTube') }}">
+        <span class="video-play-icon" aria-hidden="true"></span>
+      </button>
     {% elif provider == "vimeo" %}
       <iframe
         src="https://player.vimeo.com/video/{{ id }}"


### PR DESCRIPTION
## Summary

- **#205 — Videos con pantalla negra**: reemplaza el `<iframe>` lazy de YouTube por un facade (thumbnail `hqdefault.jpg` + botón play CSS). El iframe se carga solo al hacer click, evitando la pantalla negra inicial. En las secciones de listing también se muestra el thumbnail usando `video_id` del frontmatter (agregado a los 58 archivos de video).
- **#206 — Alineación del masthead**: en desktop (lg+), "DE MARTÍN GAITÁN" ahora tiene `margin-left: 2em; margin-top: -0.6em` para alinearse visualmente con el tallo de la "T" en "Textos y Pretextos".

## Test plan

- [ ] Abrir un artículo de video (ej. `/videos/mamita-peyote/`) y verificar que se ve el thumbnail en lugar de pantalla negra; al clickear el play, carga el video
- [ ] Verificar que las secciones de video en home sidebar y `/videos/` muestran thumbnails de YouTube
- [ ] En desktop (≥1024px), verificar que "DE MARTÍN GAITÁN" está alineado con el tallo de la "T" del título
- [ ] En mobile, verificar que el masthead se ve sin cambios (margin solo aplica en lg+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)