### PR TITLE
fix: "De otros" → "De otres" en títulos de sección (#76)

### DIFF
--- a/content/de-otros/8n-yo-no-voy.md
+++ b/content/de-otros/8n-yo-no-voy.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 439
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Yo no voy. Claro que no voy. Que no vaya no significa que piense que está todo bien, que no hay nada que criticar o que cambiar. No significa que yo no esté también enojado por algunas cosas. Significa que creo que…"
 visits = 2741
 popularite = 0.3541938898641551

--- a/content/de-otros/_index.md
+++ b/content/de-otros/_index.md
@@ -1,5 +1,5 @@
 +++
-title = "De otros"
+title = "De otres"
 sort_by = "date"
 template = "section.html"
 page_template = "article.html"

--- a/content/de-otros/a-la-orilla-de-la-chimenea.md
+++ b/content/de-otros/a-la-orilla-de-la-chimenea.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 262
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Puedo ponerme cursi y decir que tus labios me saben igual que los labios que beso en mis sueños, puedo ponerme triste y decir que me basta con ser tu enemigo, tu todo, tu esclavo, tu fiebre, tu dueño. Y si quieres…"
 visits = 1470
 popularite = 0.3527155980605535

--- a/content/de-otros/a-mi-no-me-la-vas-a-contar-1951.md
+++ b/content/de-otros/a-mi-no-me-la-vas-a-contar-1951.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 437
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Resulta que antes no te importaba nada y ahora te importa todo. Sobre todo lo chiquito. Pasaste de náufrago a financista sin bajarte del bote. Vos, sí, vos, que ya estabas acostumbrado a saber que tu patria era la…"
 visits = 94144
 popularite = 0.7407276545126769

--- a/content/de-otros/a-traves-de-tus-ojos.md
+++ b/content/de-otros/a-traves-de-tus-ojos.md
@@ -20,7 +20,7 @@ tags = [
 [extra]
 legacy_id = 78
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "A través de tus ojos. Una canción de La Portuaria sobre el tiempo compartido, la intimidad y la mirada amorosa."
 visits = 0
 popularite = 0.0

--- a/content/de-otros/aire-durando.md
+++ b/content/de-otros/aire-durando.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 441
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "¿Quién ha matado este hombre que su voz no está enterrada? Hay muertos que van subiendo cuanto más su ataúd baja... Este sudor... ¿por quién muere? ¿por qué cosa muere un pobre? ¿Quién ha matado estas manos? ¡No cabe…"
 visits = 3227
 popularite = 0.9071571480694836

--- a/content/de-otros/ajedrez.md
+++ b/content/de-otros/ajedrez.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 153
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "I En su grave rincón, los jugadores rigen las lentas piezas. El tablero los demora hasta el alba en su severo ámbito en que se odian dos colores. Adentro irradian mágicos rigores las formas: torre homérica, ligero…"
 visits = 5405
 popularite = 0.9092406411513844

--- a/content/de-otros/algo-muy-grave-va-a-suceder-en.md
+++ b/content/de-otros/algo-muy-grave-va-a-suceder-en.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 436
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Imagínese usted un pueblo muy pequeño donde hay una señora vieja que tiene dos hijos, uno de 17 y una hija de 14. Está sirviéndoles el desayuno y tiene una expresión de preocupación. Los hijos le preguntan qué le pasa…"
 visits = 10178
 popularite = 0.9268310975041049

--- a/content/de-otros/amablemente.md
+++ b/content/de-otros/amablemente.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 206
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "La encontró en el bulín y en otros brazos... Sin embargo, canchero y sin cabrearse, Le dijo al gavilán: \"Puede rajarse; el choma no es culpable en estos casos.\" Al quedarse bien solo con la mina, buscó las alpargatas…"
 visits = 1928
 popularite = 0.4213978477805894

--- a/content/de-otros/amapola.md
+++ b/content/de-otros/amapola.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 401
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Abre las hojas del viento, mi vida, ponle una montura al río. Cabalga y si te da frío te arropas con la piel de las estrellas. De almohada la luna llena, mi vida, y de sueño el amor mío. Y una amapola me lo dijo ayer…"
 visits = 7453
 popularite = 0.3655757882649118

--- a/content/de-otros/animales-domesticos.md
+++ b/content/de-otros/animales-domesticos.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 356
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Desde que Felipe trajo esa estufa de kerosene no se puede respirar en esta casa. --Quería darte una sorpresa-- dijo cuando cortaba el hilo del paquete. --Sabés que no aguanto el kerosene. Me da alergia. --En esta casa…"
 visits = 2794
 popularite = 0.9269723057904171

--- a/content/de-otros/aplastamiento-de-las-gotas.md
+++ b/content/de-otros/aplastamiento-de-las-gotas.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 124
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Yo no sé, mirá, es terrible cómo llueve. Llueve todo el tiempo, afuera tupido y gris, aquí contra el balcón con goterones cuajados y duros, que hacen plaf y se aplastan como bofetadas uno detrás de otro qué hastío…"
 visits = 10210
 popularite = 0.9412514114821786

--- a/content/de-otros/article419.md
+++ b/content/de-otros/article419.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 419
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Despiértese, que es tarde, me grita desde la puerta un hombre extraño. Despiértese usted, que buena falta le hace, le contesto yo. Pero el muy obstinado me sigue soñando."
 visits = 2404
 popularite = 0.9062808063816475

--- a/content/de-otros/asalto-al-palacio-nacional.md
+++ b/content/de-otros/asalto-al-palacio-nacional.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 333
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "El plan parecía una locura demasiado simple. Se trataba de tomar el Palacio Nacional de Managua a pleno día, con solo veinticinco hombres, mantener en rehenes a los miembros de la Cámara de Diputados y obtener como…"
 visits = 1005
 popularite = 0.9105340946762814

--- a/content/de-otros/aurorita.md
+++ b/content/de-otros/aurorita.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 449
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Invierno en la avenida Juan B. Justo y el viejo pedaleando en la Aurorita rosada de la nena. Un pullover y otro y camiseta, la campera del Shopping Abasto está muy cara, la motito alemana está muy cara, la bici con…"
 visits = 0
 popularite = 0.0

--- a/content/de-otros/ausencia-de-amor.md
+++ b/content/de-otros/ausencia-de-amor.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 132
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Cómo será pregunto. Cómo será tocarte a mi costado. Ando de loco por el aire que ando que no ando. Cómo será acostarme en tu país de pechos tan lejano. Ando de pobrecristo a tu recuerdo clavado, reclavado. Será ya como…"
 visits = 5482
 popularite = 0.9074844390415828

--- a/content/de-otros/ayer.md
+++ b/content/de-otros/ayer.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 392
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Ayer pasó el pasado lentamente con su vacilación definitiva sabiéndote infeliz y a la deriva con tus dudas selladas en la frente ayer pasó el pasado por el puente y se llevó tu libertad cautiva cambiando su silencio en…"
 visits = 0
 popularite = 0.0

--- a/content/de-otros/bala-en-el-cerebro.md
+++ b/content/de-otros/bala-en-el-cerebro.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 330
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Anders llegó al banco poco antes de la hora de cierre, así que por supuesto la cola era interminable y quedó ubicado detrás de dos mujeres que, con su estridente y estúpida conversación, lo pusieron de un humor…"
 visits = 0
 popularite = 0.0

--- a/content/de-otros/benditos-malditos-viii.md
+++ b/content/de-otros/benditos-malditos-viii.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 210
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Benditas sean las rubias calentonas que se bajan las bragas con cualquiera, las niñeras que salen respondonas y arrinconan al niño en la escalera, las enfermeras que suben la fiebre, las tetas de pezón hospitalario…"
 visits = 2882
 popularite = 0.9058795232834082

--- a/content/de-otros/besos-atras.md
+++ b/content/de-otros/besos-atras.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 395
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Es olvidar todo este tiempo que vendrá trayendo un fin. Es olvidar todo lo triste del sufrir que ha de llegar. Es olvidar, llenar vacíos que se irán. Guardar palabras, callar sueños sin seguir ya comenzando el amor con…"
 visits = 513
 popularite = 0.9045389843460049

--- a/content/de-otros/besos.md
+++ b/content/de-otros/besos.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 121
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Hay besos que pronuncian por sí solos la sentencia de amor condenatoria, hay besos que se dan con la mirada hay besos que se dan con la memoria. Hay besos silenciosos, besos nobles hay besos enigmáticos, sinceros hay…"
 visits = 4186
 popularite = 0.2504463719784405

--- a/content/de-otros/bievenida.md
+++ b/content/de-otros/bievenida.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 438
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Se me ocurre que vas a llegar distinta no exactamente más linda ni más fuerte ni más dócil ni más cauta tan solo que vas a llegar distinta como si esta temporada de no verme te hubiera sorprendido a vos también quizá…"
 visits = 0
 popularite = 0.0

--- a/content/de-otros/cancion-de-amor-contigo.md
+++ b/content/de-otros/cancion-de-amor-contigo.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 181
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Si debo hacer una caricia, preferiría que fuera a ti. Si tengo que dar algún beso, busco tu boca y lo dejo allí Si es necesario hacer futuro, desde tu cuerpo lo inventaré. Si el mundo pide decisiones, las tomarás y las…"
 visits = 10886
 popularite = 0.3527275183064846

--- a/content/de-otros/cancion-de-amor.md
+++ b/content/de-otros/cancion-de-amor.md
@@ -20,7 +20,7 @@ tags = [
 [extra]
 legacy_id = 378
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Pido que las noches no se quiebren en tu luz Y que las ventanas sean grandes para el sol Cuando los almendros no se pasen de estación Buscaré más flores para darte mi canción de amor. Pido atardeceres en los cielos de…"
 visits = 902
 popularite = 0.9087395783257712

--- a/content/de-otros/carta-abierta-del-sindicato-de-obreros-portuarios-a-la.md
+++ b/content/de-otros/carta-abierta-del-sindicato-de-obreros-portuarios-a-la.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 435
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Señora Dickinson, porque sabemos ser corteses, en ocasión de que la hija del compañero García le comentara unos versos suyos que oyó en la escuela: Multiplicar los muelles no disminuye el mar. El compañero los trajo a…"
 visits = 5916
 popularite = 0.9127070350485231

--- a/content/de-otros/cartas-de-amor-que-se-queman.md
+++ b/content/de-otros/cartas-de-amor-que-se-queman.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 163
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Ay niña no queda nada de todo lo que soñamos nuestro amor son estas llamas que estan quemando mis manos nuestro amor son estas llamas que estan quemando mis manos Son como una ala de luto volando papel quemado las…"
 visits = 4834
 popularite = 0.9062441490304762

--- a/content/de-otros/chega-de-saudade.md
+++ b/content/de-otros/chega-de-saudade.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 305
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Vai, minha tristeza E diz a ela Que sem a ela não pode ser Disse numa prece Que ela regresse Porque eu não posso mais sofrer Chega de saudade A realidade é que sem ela não há mais paz, não há beleza É só tristeza e…"
 visits = 3185
 popularite = 0.35522821501259016

--- a/content/de-otros/chicas.md
+++ b/content/de-otros/chicas.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 308
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Ayer fue el Día Internacional de la Mujer, o algo así, y quería --con muchísimas prevenciones-- decirte algo sobre eso. Lo de las prevenciones es natural: cualquier mujer se enoja si se habla de ellas solo en su día, y…"
 visits = 5694
 popularite = 0.492067828210331

--- a/content/de-otros/coger-en-castellano.md
+++ b/content/de-otros/coger-en-castellano.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 257
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "No están desnudas. Pero casi. Algunas sonriendo, o serias en pose hot, o con anteojos de sol, boca abajo en la cama, casi pegándose el culo con los talones, mostrando las marcas del bronceado, o con bombachas de…"
 visits = 83738
 popularite = 0.6864202903160397

--- a/content/de-otros/colinas-como-elefantes-blancos.md
+++ b/content/de-otros/colinas-como-elefantes-blancos.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 322
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Del otro lado del valle del Ebro, las colinas eran largas y blancas. De este lado no había sombra ni árboles y la estación se alzaba al rayo del sol, entre dos líneas de rieles. Junto a la pared de la estación caía la…"
 visits = 8772
 popularite = 0.9652204032819879

--- a/content/de-otros/colombina.md
+++ b/content/de-otros/colombina.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 302
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "En el tumulto de los húsares de Momo encandilado por las luces de otro barrio aquel murguista saludando con su gorro se despedía, como siempre, del tablado Entre la nube de pintados chiquilines vió la sonrisa que…"
 visits = 2498
 popularite = 0.9072392306963571

--- a/content/de-otros/con-ademas-antiguo.md
+++ b/content/de-otros/con-ademas-antiguo.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 361
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "En el vapor del baño se dibuja desnuda y luminosa. Ceremoniosamente, abre una toalla azul, se inclina en una reverencia para el dios de toda su belleza. El pelo en catarata hacia adelante. Lleva suave la toalla hasta…"
 visits = 2568
 popularite = 0.9065254179568324

--- a/content/de-otros/conservas.md
+++ b/content/de-otros/conservas.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 371
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Pasa una semana, un mes, y vamos haciéndonos la idea de que Teresita se adelantará a nuestros planes. Voy a tener que renunciar a la beca de estudios porque dentro de unos meses ya no va a ser fácil seguir. Quizá no…"
 visits = 7031
 popularite = 0.3527096577428952

--- a/content/de-otros/corso.md
+++ b/content/de-otros/corso.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 354
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Vos sabés cómo nos divertimos, el corso era un asco pero nosotros nos divertimos igual. El Ángel se consiguió unos plumachos, dice que los trajo de la isla y que crecen en una planta, pero eran como plumas de avestruz…"
 visits = 5586
 popularite = 0.9148080758655842

--- a/content/de-otros/cuatro-fantasticos.md
+++ b/content/de-otros/cuatro-fantasticos.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 287
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Hubo alguien antes pero yo no lo conocí. Aunque muchos me dicen que tengo algo de su carácter y de su boca. Esas cosas. A mí no me preocupa paracerme a alguien. Hay tantas caras en el mundo que uno, tarde o temprano…"
 visits = 11667
 popularite = 0.9056547023626682

--- a/content/de-otros/cuento-de-horror.md
+++ b/content/de-otros/cuento-de-horror.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 155
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "La señora Smithson, de Londres (estas historias siempre ocurren entre ingleses) resolvió matar a su marido, no por nada sino porque estaba harta de él después de cincuenta años de matrimonio. Se lo dijo: -- Thaddeus…"
 visits = 5115
 popularite = 0.902651706772405

--- a/content/de-otros/de-vidas-ajenas-fragmentos.md
+++ b/content/de-otros/de-vidas-ajenas-fragmentos.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 405
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Cultivar nuestro jardín \"Otra cosa que compartía con Jérôme y que es rara en un muchacho de su edad: esa forma de mirar ligeramente socarrona, sin malevolencia, a esa gente que se agita y se estresa e intriga, que…"
 visits = 1579
 popularite = 0.9075215540682732

--- a/content/de-otros/defensa-de-la-alegria.md
+++ b/content/de-otros/defensa-de-la-alegria.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 236
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Defender la alegría como una trinchera defenderla del escándalo y la rutina de la miseria y los miserables de las ausencias transitorias y las definitivas defender la alegría como un principio defenderla del pasmo y…"
 visits = 12736
 popularite = 0.9056624156109147

--- a/content/de-otros/desganas.md
+++ b/content/de-otros/desganas.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 120
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Si cuarenta mil niños sucumben diaramente en el purgatorio del hambre y de la sed si la tortura de los pobres cuerpos envilece una a una a las almas y si el poder se ufana de sus cuarentenas o si los pobres de…"
 visits = 3867
 popularite = 0.9048234532829699

--- a/content/de-otros/diario-de-viaje-de-un-mochilero.md
+++ b/content/de-otros/diario-de-viaje-de-un-mochilero.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 397
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Hoy estuvimos en Lima; no teníamos un cobre, loco. Así que pintó ir a la plaza central a tirar paños, a manguear algo para hacer el día. Nos mandamos yo, que zafo con la escribanía pública y hago algo con la…"
 visits = 1348
 popularite = 0.9067183771843479

--- a/content/de-otros/dibaxu-xxi.md
+++ b/content/de-otros/dibaxu-xxi.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 450
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "en la noche tu vientre detiene astros/ respira como tierra/ tu vientre es tierra/ en el trigo de tu vientre vuelan pájaros que cantan en lo que va a venir/ --o-- nila nochi tu ventre queda astrus/ respira comu terra/…"
 visits = 5571
 popularite = 0.9676193583279015

--- a/content/de-otros/dulce-daniela.md
+++ b/content/de-otros/dulce-daniela.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 300
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Ella decide cuando es de día, ella maneja el sol anda pintando toda la casa con trozos de crayón. Rojo a los muros, verde al oscuro sillón del comedor, y un póquitito de azul celeste aquí en mi corazón. El amarillo…"
 visits = 1510
 popularite = 0.9070235089757736

--- a/content/de-otros/edad-201.md
+++ b/content/de-otros/edad-201.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 201
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "¿Qué se puede hacer en ochenta años? Probablemente, empezar a darse cuenta de cómo habría de vivir y cuáles son las tres o cuatro cosas que valen la pena. Un programa honesto requiere ochocientos años. Los primeros…"
 visits = 1282
 popularite = 0.9096388714429534

--- a/content/de-otros/edad.md
+++ b/content/de-otros/edad.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 98
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "¿Qué se puede hacer en ochenta años? Probablemente, empezar a darse cuenta de cómo habría de vivir y cuáles son las tres o cuatro cosas que valen la pena. Un programa honesto requiere ochocientos años. Los primeros…"
 visits = 2262
 popularite = 0.9025665138590587

--- a/content/de-otros/el-alma-del-guerrero.md
+++ b/content/de-otros/el-alma-del-guerrero.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 184
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "(...)Mirá, cortá el pan dulce que te voy a leer una carta de Conrad a su amigo Edward Garnett: \"Tiene razón en su crítica de mi novela. La estructura es mala. Es mala porque la decidí conscientemente y yo no tengo…"
 visits = 2081
 popularite = 0.9090167875128295

--- a/content/de-otros/el-amor-despues-de-todo.md
+++ b/content/de-otros/el-amor-despues-de-todo.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 396
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "El amor se aprende, se hace, se inventa, se contagia… y también se acaba. Queramos o no, dura lo que dura. El amor caduca sin previo aviso y no admite reclamaciones ni devoluciones. El amor es así. Improbable…"
 visits = 905
 popularite = 0.9057542980764269

--- a/content/de-otros/el-dolar-de-los-ranchos.md
+++ b/content/de-otros/el-dolar-de-los-ranchos.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 423
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "En 1998, el país parecía vivir un tiempo de vacas gordas. Era el tiempo del despilfarro procaz del dólar. Pero había también, en el interior del país, sobre todo, otra Argentina. Por entonces, yo estaba terminando mi…"
 visits = 470
 popularite = 0.9060722089944736

--- a/content/de-otros/el-enamorado.md
+++ b/content/de-otros/el-enamorado.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 97
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Lunas, marfiles, instrumentos, rosas, lamparas y la linea de Durero, las nueve cifras y el cambiante cero, debo fingir que existen esas cosas. Debo fingir que en el pasado fueron Persepolis y Roma y que una arena sutil…"
 visits = 1896
 popularite = 0.9065415706045545

--- a/content/de-otros/el-hombre-que-aprendio-a-ladrar.md
+++ b/content/de-otros/el-hombre-que-aprendio-a-ladrar.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 275
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Lo cierto es que fueron años de arduo y pragmático aprendizaje, con lapsos de desaliento en los que estuvo a punto de desistir. Pero al fin triunfó la perseverancia y Raimundo aprendió a ladrar. No a imitar ladridos…"
 visits = 4509
 popularite = 0.9748393149212815

--- a/content/de-otros/el-juego-en-que-andamos.md
+++ b/content/de-otros/el-juego-en-que-andamos.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 176
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Si me dieran a elegir, yo elegiría esta salud de saber que estamos muy enfermos, esta dicha de andar tan infelices. Si me dieran a elegir, yo elegiría esta inocencia de no ser un inocente, esta pureza en que ando por…"
 visits = 2379
 popularite = 0.9075205894872277

--- a/content/de-otros/el-lagarto-esta-llorando.md
+++ b/content/de-otros/el-lagarto-esta-llorando.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 376
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "El lagarto está llorando. La lagarta está llorando. El lagarto y la lagarta con delantaritos blancos. Han perdido sin querer su anillo de desposados. ¡Ay, su anillito de plomo, ay, su anillito plomado! Un cielo grande…"
 visits = 665
 popularite = 0.9081298074090259

--- a/content/de-otros/el-nino-que-fue-a-menos.md
+++ b/content/de-otros/el-nino-que-fue-a-menos.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 234
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "La señorita Claudia le pregunta a Ferro: -- ¿Quién fundó la ciudad de Asunción? Ferro lo ignora y lo confiesa. La maestra intenta por otros rumbos. -- Tissot. -- No sé, señorita. -- Rossi. Silencio. El ambiente se pone…"
 visits = 7788
 popularite = 0.9064506206617594

--- a/content/de-otros/el-olvidao.md
+++ b/content/de-otros/el-olvidao.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 212
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "De tu palo soy, hijo de tu cuero soy el olvidao en la alcancía del tiempo el que se quedó de pie poniéndote el pecho. Flor obrera soy, silvestre de espuma cuando el tren se va miro en las vías la luna pensando tal vez…"
 visits = 2050
 popularite = 0.7421601795674655

--- a/content/de-otros/el-oso.md
+++ b/content/de-otros/el-oso.md
@@ -16,7 +16,7 @@ tags = [
 
 [extra]
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "En este momento, el corazón de un oso pardo / late apenas ocho veces por minuto. / Una pizca de energía que gaste de más / y no podría salir vivo de este invierno."
 hero_image = ""
 hero_alt = ""

--- a/content/de-otros/el-padre.md
+++ b/content/de-otros/el-padre.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 329
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "El bebé estaba en una canasta al lado de la cama, y llevaba puesto un osito y un gorro blanco. La canasta de mimbre estaba recién pintada, acolchada con pequeños edredones azules y sujeta con cintas de color azul…"
 visits = 0
 popularite = 0.0

--- a/content/de-otros/el-puro-no.md
+++ b/content/de-otros/el-puro-no.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 352
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "El No el no inóvulo el no nonato el noo el no poslodocosmos de impuros ceros noes que noan noan noan y nooan y plurimono noan el morbo amorfo noo no démono no deo sin son sin sexo ni órbita el yerto inóseo noo en…"
 visits = 6065
 popularite = 0.9051037231994207

--- a/content/de-otros/el-salon-de-bailes-sin-banos-o-el.md
+++ b/content/de-otros/el-salon-de-bailes-sin-banos-o-el.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 273
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Un pintoresco croquis del Atlas señala en la calle Yatay un enorme salón de baile. A pesar de su lujosa apariencia, el local no tenia baños. Sucedía entonces que los bailarines se veían obligados a abandonar la milonga…"
 visits = 3238
 popularite = 0.9059914195522848

--- a/content/de-otros/el-score-macabro-de-los-muertos.md
+++ b/content/de-otros/el-score-macabro-de-los-muertos.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 358
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Nadie se pregunta para qué sirven los embajadores argentinos en cada país del mundo. Les sospechamos actividades poco esforzadas, los imaginamos en perpetuos ágapes, y siempre conocemos a alguien que conoce al hijo o a…"
 visits = 717
 popularite = 0.9592294035436403

--- a/content/de-otros/el-sentimiento-de-la-poesia-en-la.md
+++ b/content/de-otros/el-sentimiento-de-la-poesia-en-la.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 335
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "El sentimiento de la poesía en la infancia: me gustaría saber más, pero temo caer en las extrapolaciones a la inversa, recordar obligadamente desde el hic et nunc que deforma casi siempre el pasado (Proust incluído…"
 visits = 4971
 popularite = 0.9393818730261312

--- a/content/de-otros/el-sexo-de-los-angeles.md
+++ b/content/de-otros/el-sexo-de-los-angeles.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 421
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Una de las más lamentables carencias de información que han padecido los hombres y mujeres de todas las épocas, se relaciona con el sexo de los ángeles. El dato, nunca confirmado, de que los ángeles no hacen el amor…"
 visits = 0
 popularite = 0.0

--- a/content/de-otros/el-tiempo-esta-despues.md
+++ b/content/de-otros/el-tiempo-esta-despues.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 387
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "La calle Llupes raya al medio encuentra Belvedere el tren saluda desde abajo con silbos de tristeza aquellas filas infinitas saliendo de Central el empedrado está tapado pero allí está La primavera en aquel barrio se…"
 visits = 2212
 popularite = 0.9072258348093631

--- a/content/de-otros/el-vendedor-de-naranjas.md
+++ b/content/de-otros/el-vendedor-de-naranjas.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 264
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "El hombre que maneja la niveladora de terreno, mira el banderín azul con ansiedad. Tiene las manos al volante, y un cigarrillo apagado en la boca. El sol brilla con desenfado y entonces el hombre se seca una gota que…"
 visits = 1126
 popularite = 0.9066396752886733

--- a/content/de-otros/ella-sonaba-con-vivir-en-bahia.md
+++ b/content/de-otros/ella-sonaba-con-vivir-en-bahia.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 299
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Ella soñaba con vivir en Bahía, pero en San Telmo sobrevivía; tomaba clases de teatro independiente era feliz mostrando el culo a tanta gente inteligente. Tomaba leche en La Martona de Corrientes y se las daba de mujer…"
 visits = 0
 popularite = 0.0

--- a/content/de-otros/en-estos-dias.md
+++ b/content/de-otros/en-estos-dias.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 224
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "A la mujer que amo y me ama En estos días, todo el viento del mundo sopla en tu dirección La osa mayor corrige la punta de su cola Y te corona con la estrella que guía: la mía Los mares se han torcido con no poco dolor…"
 visits = 1241
 popularite = 0.908636336380697

--- a/content/de-otros/en-la-cancha-se-ven-los-pingos.md
+++ b/content/de-otros/en-la-cancha-se-ven-los-pingos.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 370
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Me agarró la fiebre clasificatoria y empecé por ordenar mis zapatos, después mi biblioteca, después los papeles que daban vueltas hace meses, y ahora quiero terminar etiquetando los estilos sexuales de los hombres…"
 visits = 2225
 popularite = 0.42209615354441127

--- a/content/de-otros/ensayo-sobre-las-tetas.md
+++ b/content/de-otros/ensayo-sobre-las-tetas.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 343
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Ahora que llega el calor y por toda la ciudad afloran las tetas con su vanguardia prometedora de un tiempo blando, vale quizá entregarse a esa curiosidad primaria que generan las tetas en la vida de los hombres…"
 visits = 3273
 popularite = 0.98177941039578

--- a/content/de-otros/es-que-somos-muy-pobre.md
+++ b/content/de-otros/es-que-somos-muy-pobre.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 332
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Aquí todo va de mal en peor. La semana pasada se murió mi tía Jacinta, y el sábado, cuando ya la habíamos enterrado y comenzaba a bajársenos la tristeza, comenzó a llover como nunca. A mi papá eso le dio coraje, porque…"
 visits = 0
 popularite = 0.0

--- a/content/de-otros/es-que-somos-muy-pobres.md
+++ b/content/de-otros/es-que-somos-muy-pobres.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 253
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Aquí todo va de mal en peor. La semana pasada se murió mi tía Jacinta, y el sábado, cuando ya la habíamos enterrado y comenzaba a bajársenos la tristeza, comenzó a llover como nunca. A mi papá eso le dio coraje, porque…"
 visits = 19719
 popularite = 0.25749117029702856

--- a/content/de-otros/es-tiempo-de-union.md
+++ b/content/de-otros/es-tiempo-de-union.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 433
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Es tiempo de unión, tiempo de que juntemos las manos y desafiemos la muerte. Las naranjas están dulces en los palos, se desgajan pesadas para que tu y yo comamos la ternura de la naturaleza. Es tiempo de decir te…"
 visits = 988
 popularite = 0.9033216032426754

--- a/content/de-otros/esa-mujer.md
+++ b/content/de-otros/esa-mujer.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 366
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "El coronel elogia mi puntualidad: --Es puntual como los alemanes --dice. --O como los ingleses. El coronel tiene apellido alemán. Es un hombre corpulento, canoso, de cara ancha, tostada. --He leído sus cosas…"
 visits = 1565
 popularite = 0.43083331751999526

--- a/content/de-otros/escribo-en-el-olvido.md
+++ b/content/de-otros/escribo-en-el-olvido.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 179
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Escribo en el olvido en cada fuego de la noche cada rostro de ti. Hay una piedra entonces donde te acuesto mía, ninguno la conoce, he fundado pueblos en tu dulzura, he sufrido esas cosas, eres fuera de mí, me…"
 visits = 2019
 popularite = 0.25135378237919914

--- a/content/de-otros/esdrujulo.md
+++ b/content/de-otros/esdrujulo.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 227
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "A La Rousis Se trata cósmicos de ser más fértiles, de no ser tímidos, de ser más trópicos, de ir a lo pálido, volverlo térmico, sentirse prójimo de lo más lúdico, con verdes lápices trazar el ámbito de lo que mágico…"
 visits = 1307
 popularite = 0.9053894702205999

--- a/content/de-otros/eso.md
+++ b/content/de-otros/eso.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 276
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Al preso lo interrogaban tres veces por semana para averiguar «quien le había enseñado eso». Él siempre respondía con un digno silencio y entonces el teniente de turno arrimaba a sus testículos la horrenda picana. Un…"
 visits = 3814
 popularite = 0.9073778081269231

--- a/content/de-otros/espantapajaros-3.md
+++ b/content/de-otros/espantapajaros-3.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 353
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Nunca he dejado de llevar la vida humilde que puede permitirse un modesto empleado de correos. ¡Pues! mi mujer —que tiene la manía de pensar en voz alta y de decir todo lo que le pasa por la cabeza— se empeña en…"
 visits = 4976
 popularite = 0.4215557905110288

--- a/content/de-otros/estoy-contigo.md
+++ b/content/de-otros/estoy-contigo.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 390
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Estoy contigo, pero por encima de tu hombro me dice adiós tu mano que se aleja. Entonces yo contengo mi mano para que no nos traicione ella también. E insisto: estoy contigo. Los innegables títulos del adiós abandonan…"
 visits = 1184
 popularite = 0.3527492824813419

--- a/content/de-otros/fabricas-tomadas-viaje-al-interior-de-un-sueno-real.md
+++ b/content/de-otros/fabricas-tomadas-viaje-al-interior-de-un-sueno-real.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 382
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "INTRODUCCIÓN: El cerámico y los retratos \"Lock out\" es el sinónimo de huelga patronal y es utilizada por los patrones para imponer sus \"demandas\" a los trabajadores; baja de salarios, despidos, suspensiones o…"
 visits = 945
 popularite = 0.5796679912664636

--- a/content/de-otros/felicidad-clandestina.md
+++ b/content/de-otros/felicidad-clandestina.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 331
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "lla era gorda, baja, pecosa y de pelo excesivamente crespo, medio amarillento. Tenía un busto enorme, mientras que todas nosotras todavía eramos chatas. Como si no fuese suficiente, por encima del pecho se llenaba de…"
 visits = 0
 popularite = 0.0

--- a/content/de-otros/gente-213.md
+++ b/content/de-otros/gente-213.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 213
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "A mi gente Hay gente que con sólo decir una palabra enciende la ilusión y los rosales, que con sólo sonreir entre los ojos nos invita a viajar por otras zonas y nos hace recorrer toda la mágia. Hay gente que con sólo…"
 visits = 1318
 popularite = 0.9080295988238771

--- a/content/de-otros/gorriones.md
+++ b/content/de-otros/gorriones.md
@@ -16,7 +16,7 @@ tags = [
 
 [extra]
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Llegó el verano y con el verano el tiempo de arreglar la casa. Mi padre apoyó la escalera sobre una de las paredes y se trepó al techo."
 hero_image = ""
 hero_alt = ""

--- a/content/de-otros/gracias-por-el-fuego-fragmento.md
+++ b/content/de-otros/gracias-por-el-fuego-fragmento.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 172
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Porque te tengo y no porque te pienso porque la noche está de ojos abiertos porque la noche pasa y digo amor porque has venido a recoger tu imagen y eres mejor que todas tus imágenes porque eres linda desde el pie…"
 visits = 111578
 popularite = 0.909474549999842

--- a/content/de-otros/gravitacion.md
+++ b/content/de-otros/gravitacion.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 420
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Los abismos atraen. Yo vivo en la orilla de tu alma. Inclinado hacia ti, sondeo tus pensamientos, indago el germen de tus actos. Vagos deseos se remueven en el fondo, confusos y ondulantes en su lecho de reptiles. ¿De…"
 visits = 0
 popularite = 0.0

--- a/content/de-otros/hagamos-un-trato.md
+++ b/content/de-otros/hagamos-un-trato.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 192
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "cuando sientas tu voz sollozar cuenta conmigo|autor=de una canción de Carlos Puebla> Compañera, usted sabe que puede contar conmigo, no hasta dos ni hasta diez sino contar conmigo. Si algunas veces advierte que la miro…"
 visits = 11454
 popularite = 0.9077470659938383

--- a/content/de-otros/happy-new-year.md
+++ b/content/de-otros/happy-new-year.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 414
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Mira, no pido mucho, solamente tu mano, tenerla como un sapito que duerme así contento. Necesito esa puerta que me dabas para entrar a tu mundo, ese trocito de azúcar verde, de redondo alegre. ¿No me prestás tu mano en…"
 visits = 5703
 popularite = 0.9104279001615339

--- a/content/de-otros/hermanos.md
+++ b/content/de-otros/hermanos.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 447
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Aire, fuego y agua casi sin querer alzan las montañas, las dejan caer. Rigen los destinos, por allá o aquí nunca, nadie, nada te alejará de mí. Hijo, madre, hermano, toman sin pensar sendas diferentes, propios de su…"
 visits = 4531
 popularite = 0.9071772122636592

--- a/content/de-otros/historia-de-una-mujer-bomba.md
+++ b/content/de-otros/historia-de-una-mujer-bomba.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 440
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "San Miguel de Tucumán, la capital de Tucumán, una provincia ubicada en el Norte de la Argentina, tiene sus calles repletas de naranjos. Están dispuestos en hilera en casi todas las aceras y eso hace que la ciudad…"
 visits = 41339
 popularite = 0.8781274233633689

--- a/content/de-otros/horal.md
+++ b/content/de-otros/horal.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 122
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "El mar se mide por olas, el cielo por alas, nosotros por lágrimas. El aire descansa en las hojas, el agua en los ojos, nosotros en nada. Parece que hay sales y soles, nosotros y nada..."
 visits = 5948
 popularite = 0.9063779520706314

--- a/content/de-otros/idilio-muerto.md
+++ b/content/de-otros/idilio-muerto.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 280
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Qué estará haciendo esta hora mi andina y dulce Rita de junco y capulí; ahora que me asfixia Bizancio, y que dormita la sangre, como flojo coñac, dentro de mí. Dónde estarán sus manos que en actitud contrita planchaban…"
 visits = 1686
 popularite = 0.42150884961449947

--- a/content/de-otros/isadora.md
+++ b/content/de-otros/isadora.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 429
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "1916-Buenos Aires Descalza, desnuda, apenas envuelta en la bandera argentina, Isadora Duncan baila el himno nacional. Una noche comete esa osadía, en un café de estudiantes de Buenos Aires y a la mañana siguiente todo…"
 visits = 8894
 popularite = 0.908130339859081

--- a/content/de-otros/juan-lopez-y-john-ward.md
+++ b/content/de-otros/juan-lopez-y-john-ward.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 327
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Les tocó en suerte una época extraña. El planeta había sido parcelado en distintos países, cada uno provisto de lealtades, de queridas memorias, de un pasado sin duda heroico, de derechos, de agravios, de una mitología…"
 visits = 0
 popularite = 0.0

--- a/content/de-otros/juan-y-el-sol.md
+++ b/content/de-otros/juan-y-el-sol.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 240
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Llovía tanto que parecía que el mundo entero se estaba licuando. Hacía un mes que no paraba. Y cuando paraba era por un ratito, algunas horas, a lo mucho amainaba medio día o toda una tarde, pero enseguida se largaba…"
 visits = 974
 popularite = 0.6805399277000869

--- a/content/de-otros/la-autopista-del-sur.md
+++ b/content/de-otros/la-autopista-del-sur.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 261
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Al principio la muchacha del Dauphine había insistido en llevar la cuenta del tiempo, aunque al ingeniero del Peugeot 404 le daba ya lo mismo. Cualquiera podía mirar su reloj pero era como si ese tiempo atado a la…"
 visits = 6419
 popularite = 0.9085093608497894

--- a/content/de-otros/la-ciudad-futura-fragmento.md
+++ b/content/de-otros/la-ciudad-futura-fragmento.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 367
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Odio a los indiferentes. Creo que vivir es tomar partido. Quien verdaderamente vive no puede dejar de ser ciudadano y partidario. Indiferencia es abulia, es parasitismo, es cobardía, no es vida. Por eso, odio a los…"
 visits = 3207
 popularite = 0.9067080058931521

--- a/content/de-otros/la-enamorada.md
+++ b/content/de-otros/la-enamorada.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 386
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Esta lúgubre manía de vivir esta recóndita humorada de vivir te arrastra alejandra no lo niegues. Hoy te miraste en el espejo y te fue triste estabas sola la luz rugía el aire cantaba pero tu amado no volvió Enviarás…"
 visits = 0
 popularite = 0.0

--- a/content/de-otros/la-fauna-embalsamada.md
+++ b/content/de-otros/la-fauna-embalsamada.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 377
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "¿esto es un poema? ¿estar a oscuras sin dormir puede ser un poema? ¿si no hay nada puede haber un poema? ¿si digo que respiro en este cubo negro, no es algo ya? ¿no es demasiado? ¿no es mucho más que esto en realidad?…"
 visits = 1075
 popularite = 0.9083129008981133

--- a/content/de-otros/la-historia-viene-de-lejos.md
+++ b/content/de-otros/la-historia-viene-de-lejos.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 109
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "El primero que lo dijo no fue Diógenes el cínico sino el cíclope Polifemo. Interrogado por Ulises sobre las razones de su misoginia, Polifemo pronunció el famoso discurso: \"Tener relaciones sexuales con una prostituta…"
 visits = 945
 popularite = 0.5799107433900417

--- a/content/de-otros/la-luna-con-gatillo.md
+++ b/content/de-otros/la-luna-con-gatillo.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 229
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Es preciso que nos entendamos. Yo hablo de algo seguro y de algo posible. Seguro es que todos coman y vivan dignamente y es posible saber algún día muchas cosas que hoy ignoramos. Entonces, es necesario que esto…"
 visits = 29250
 popularite = 0.9063374941699699

--- a/content/de-otros/la-niebla.md
+++ b/content/de-otros/la-niebla.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 363
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "La niebla lo invade todo. Este cuarto que no eligió, este mundo que no es el suyo, estos ojos desconocidos que la miran y la buscan, y que aseguran conocerla. Acá la niebla. Más allá, también la niebla. Sobre sus manos…"
 visits = 5529
 popularite = 0.9033604999180275

--- a/content/de-otros/la-orilla.md
+++ b/content/de-otros/la-orilla.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 277
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "No se animaban a meterse. Con los ojos clavados en las olas, todos parados como soldados en fila, se medían el miedo y se atrevían, a lo sumo, a mojarse los pies. Eran niños venidos de tierra adentro, de muy adentro…"
 visits = 7231
 popularite = 0.58398717143389

--- a/content/de-otros/la-pequena-muerte.md
+++ b/content/de-otros/la-pequena-muerte.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 125
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "No nos da risa el amor cuando llega a lo más hondo de su viaje, a lo más alto de su vuelo: en lo más hondo, en lo más alto, nos arranca gemidos y quejidos, voces de dolor, aunque sea jubiloso dolor, lo que pensándolo…"
 visits = 47076
 popularite = 0.9402925051548888

--- a/content/de-otros/la-que-no-esta.md
+++ b/content/de-otros/la-que-no-esta.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 89
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Ninguna tiene tanto éxito como la que no está. Aunque todavía es joven, muchos años de práctica consciente la han perfeccionado en el sutilísimo arte de la ausencia. Los que preguntan por ella terminan por conformarse…"
 visits = 692
 popularite = 0.907591078304076

--- a/content/de-otros/la-salvacion.md
+++ b/content/de-otros/la-salvacion.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 274
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Ésta es una historia de tiempos y de reinos pretéritos. El escultor paseaba con el tirano por los jardines del palacio. Más allá del laberinto para los extranjeros ilustres, en el extremo de la alameda de los filósofos…"
 visits = 0
 popularite = 0.0

--- a/content/de-otros/la-suma.md
+++ b/content/de-otros/la-suma.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 328
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Ante la cal de una pared que nada nos veda imaginar como infinita un hombre se ha sentado y premedita trazar con rigurosa pincelada en la blanca pared el mundo entero: puertas, balanzas, tártaros, jacintos, ángeles…"
 visits = 0
 popularite = 0.0

--- a/content/de-otros/la-tortura.md
+++ b/content/de-otros/la-tortura.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 278
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "La palabra mártir viene del griego, y significa: el que da testimonio. En los años de la dictadura militar brasileña, fray Tito dio testimonio de indignación entre los indignos, y fue por ellos encarcelado y…"
 visits = 7946
 popularite = 0.9075672581712685

--- a/content/de-otros/las-nubes.md
+++ b/content/de-otros/las-nubes.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 272
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Nube dejó caer una gota de lluvia sobre el cuerpo de una mujer. A los nueve meses, ella tuvo mellizos. Cuando crecieron, quisieron saber quién era su padre. -- Mañana por la mañana --dijo ella-- miren hacia el…"
 visits = 14018
 popularite = 0.9077791310156823

--- a/content/de-otros/las-ruinas-circulares.md
+++ b/content/de-otros/las-ruinas-circulares.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 326
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Nadie lo vio desembarcar en la unánime noche, nadie vio la canoa de bambú sumiéndose en el fango sagrado, pero a los pocos días nadie ignoraba que el hombre taciturno venía del Sur y que su patria era una de las…"
 visits = 0
 popularite = 0.0

--- a/content/de-otros/ligazon-408.md
+++ b/content/de-otros/ligazon-408.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 408
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Ella desnuda y yo desnudo y no hay mucho más que me importe. Las cosas caen al suelo como habiendo estado siempre en ese sitio, así caigo yo en ella. Ella apunta sus rodillas hacia dos constelaciones y es entonces la…"
 visits = 539
 popularite = 0.9075164179612479

--- a/content/de-otros/ligazon.md
+++ b/content/de-otros/ligazon.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 324
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Ella desnuda y yo desnudo y no hay mucho más que me importe. Las cosas caen al suelo como habiendo estado siempre en ese sitio, así caigo yo en ella. Ella apunta sus rodillas hacia dos constelaciones y es entonces la…"
 visits = 0
 popularite = 0.0

--- a/content/de-otros/los-burocratas.md
+++ b/content/de-otros/los-burocratas.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 317
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Los burócratas nadan en un mar de aburrimiento tempestuoso. Desde el horror de sus bostezos son los primeros asesinos de la ternura terminan por enfermarse del hígado y mueren aferrados a los teléfonos con los ojos…"
 visits = 3165
 popularite = 0.3534311603555411

--- a/content/de-otros/maestras-argentinas-clara-dezcurra.md
+++ b/content/de-otros/maestras-argentinas-clara-dezcurra.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 245
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Clara Dezcurra toma la pluma y escribe la fecha: \"16 de Julio de 1840\". Luego, con la misma letra minúscula y erguida, agrega el encabezamiento: \"Querida Juana\". Finalmente, tras alisar el papel que tiene la…"
 visits = 29535
 popularite = 0.8927374597012787

--- a/content/de-otros/malevaje.md
+++ b/content/de-otros/malevaje.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 193
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Decí, por Dios, ¿qué me has dao, que estoy tan cambiao, no sé más quien soy? El malevaje extrañao, me mira sin comprender... Me ve perdiendo el cartel de guapo que ayer brillaba en la acción... ¿No ves que estoy…"
 visits = 1422
 popularite = 0.4223062814898757

--- a/content/de-otros/margaritas.md
+++ b/content/de-otros/margaritas.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 365
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Octubre 25, 2007. --Hola María Rosa. ¿Cómo te va? --Mal. --¿Qué tenés? --Cáncer. Por eso te venía a decir dos cosas. Que no te voy a hacer la torta para el sábado, y que necesito que me pagues la deuda. Un día después…"
 visits = 3509
 popularite = 0.3527181314761368

--- a/content/de-otros/mas-alla-del-amor.md
+++ b/content/de-otros/mas-alla-del-amor.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 389
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Todo nos amenaza: el tiempo, que en vivientes fragmentos divide al que fui del que seré, como el machete a la culebra; la conciencia, la transparencia traspasada, la mirada ciega de mirarse mirar; las palabras, guantes…"
 visits = 0
 popularite = 0.0

--- a/content/de-otros/mejor-asi.md
+++ b/content/de-otros/mejor-asi.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 424
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Sepa que aquí tiene prenda mía por si precisa algún día el hombro firme, casa en mi pecho y la alegría de darte toda la vida. Yo no tengo nada, te soy sincero pero te quiero para acompañarte. He de poner el hombro…"
 visits = 14508
 popularite = 0.2538657283835905

--- a/content/de-otros/menina-da-lua.md
+++ b/content/de-otros/menina-da-lua.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 233
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "A Nati Leve na lembrança a singela melodia que eu fiz para ti ó bem amada princesa olhos d'água menina da lua Quero te ver clara clareando a noite intensa deste amor o céu é teu sorriso no branco do teu rosto a…"
 visits = 2738
 popularite = 0.9070413357971427

--- a/content/de-otros/monologo-octavo-habla-dulcinea.md
+++ b/content/de-otros/monologo-octavo-habla-dulcinea.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 431
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "No vayan a creer vuesas mercedes que soy una moza lánguida y amiga de embelecos sin bulto, de los que no se palpan ni se sienten pero hacen llorar. Arredro vayan de mi vera los pálpitos inexplicables, los suspiritos de…"
 visits = 2268
 popularite = 0.9966812718610963

--- a/content/de-otros/naranjo-en-flor.md
+++ b/content/de-otros/naranjo-en-flor.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 416
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Era más blanda que el agua, que el agua blanda, era más fresca que el río, naranjo en flor. Y en esa calle de estío, calle perdida, dejó un pedazo de vida y se marchó... Primero hay que saber sufrir, después amar…"
 visits = 466
 popularite = 0.9063651872834128

--- a/content/de-otros/ninos-corea-1952.md
+++ b/content/de-otros/ninos-corea-1952.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 269
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Esto que tengo de niño fundamental se me rebela, quiere llorar en los rincones, desgarrarse la frente, la mejilla, olvidar el cuaderno donde dice mamá con letras tiernas y hay una dulce vaca de tres patas. Hermanitos…"
 visits = 1538
 popularite = 0.9076165375324229

--- a/content/de-otros/ninos-de-plastico.md
+++ b/content/de-otros/ninos-de-plastico.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 337
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Niños de plástico juegan erráticos sueños para vivir, y en un errático vagabundeo se vuelven a consumir, en el estático mundo simpático que les dan a elegir. Mienten, mienten, qué forma de mentir. No es el mundo que…"
 visits = 865
 popularite = 0.9063337423159666

--- a/content/de-otros/no-amarse-ahora-pero-haber-amado.md
+++ b/content/de-otros/no-amarse-ahora-pero-haber-amado.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 169
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "No amarse ahora, pero haber amado. Y encontrarse otra vez... Recuerdo grave como el de alguna flor de aroma suave que se mustia en un libro ya olvidado. Va surgiendo el recuerdo desvelado: una palabra, un gesto... Es…"
 visits = 1923
 popularite = 0.9060469492297398

--- a/content/de-otros/no-hacen-falta-alas.md
+++ b/content/de-otros/no-hacen-falta-alas.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 203
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "No hacen falta alas para hacer un sueño basta con las manos basta con el pecho basta con las piernas y con el empeño. No hacen falta alas para ser más bellos basta el buen sentido del amor inmenso no hacen falta alas…"
 visits = 0
 popularite = 0.0

--- a/content/de-otros/no-se-trata-de-hablar.md
+++ b/content/de-otros/no-se-trata-de-hablar.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 388
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "No se trata de hablar, ni tampoco de callar: se trata de abrir algo entre la palabra y el silencio. Quizá cuando transcurra todo, también la palabra y el silencio, quede esa zona abierta como una esperanza hacia atrás…"
 visits = 4216
 popularite = 0.9061069810685893

--- a/content/de-otros/no-te-rindas.md
+++ b/content/de-otros/no-te-rindas.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 141
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "No te rindas, aun estas a tiempo de alcanzar y comenzar de nuevo, aceptar tus sombras, enterrar tus miedos, liberar el lastre, retomar el vuelo. No te rindas que la vida es eso, continuar el viaje, perseguir tus…"
 visits = 1682970
 popularite = 0.9241870534400456

--- a/content/de-otros/nueva-constitucion-politica-del.md
+++ b/content/de-otros/nueva-constitucion-politica-del.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 222
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Al valiente Pueblo Boliviano, que sabe de lucha, sudor y revoluciones En tiempos inmemoriales se erigieron montañas, se desplazaron ríos, se formaron lagos. Nuestra amazonia, nuestro chaco, nuestro altiplano y nuestros…"
 visits = 1735
 popularite = 0.9277035815565915

--- a/content/de-otros/nuevo-articulo.md
+++ b/content/de-otros/nuevo-articulo.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 133
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Estaba sensible. O sea bien. Pleno. Ese lugar es místico y vos , ahora, formás parte de eso. Sólo pienso en cómo sería ese paisaje con vos riendo. Las cuatro y veinte dice el monitor, y lo que cuenta la ventana parece…"
 visits = 0
 popularite = 0.0

--- a/content/de-otros/obdulio-varela-el-reposo-del.md
+++ b/content/de-otros/obdulio-varela-el-reposo-del.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 158
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Historia de vida , tal como se la conocía en el suplemento cultural de La Opinión, era una de las formas más difíciles del reportaje. Consistía en escuchar, ante un grabador, durante cinco o seis horas--tal vez más--…"
 visits = 4668
 popularite = 0.3523961796653185

--- a/content/de-otros/ofrenda-floral-a-lo-cursi.md
+++ b/content/de-otros/ofrenda-floral-a-lo-cursi.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 384
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Delirante bazar de celuloide, módico lujo de colectiveros, risa planchada de Gardel eterno con nomeolvides. Trajes de noviecitas en vidrieras, tribus de maniquíes con meñiques, Patria y Hogar y Madre hay una Sola Himno…"
 visits = 0
 popularite = 0.0

--- a/content/de-otros/palabras-para-julia.md
+++ b/content/de-otros/palabras-para-julia.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 191
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "A Julia Tú no puedes volver atrás porque la vida ya te empuja con un aullido interminable, interminable... Te sentirás acorralada te sentirás perdida o sola tal vez querrás no haber nacido, no haber nacido... Pero tú…"
 visits = 1585
 popularite = 0.9054805089956867

--- a/content/de-otros/para-vestirte-hoy.md
+++ b/content/de-otros/para-vestirte-hoy.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 112
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Puedo acariciar tu voz ser tu desierto y mirarte horas enteras. Puedo acercarme a vos y no ser tan terco pisando la basura del puerto. Desde el mar no hay piedad si vos no te mojás Se cansó la ansiedad, la pena y el…"
 visits = 8330
 popularite = 0.9134861829733387

--- a/content/de-otros/patrias.md
+++ b/content/de-otros/patrias.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 406
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "a Olga Orozco No importa que no sepas cuándo te toca la incandescencia del aire. Lo importante es que la recibas y más importante aún que abras así el país de la bondad. Los sueños no saben nada de sí mismos. También…"
 visits = 902
 popularite = 0.907178356165239

--- a/content/de-otros/peluqueria.md
+++ b/content/de-otros/peluqueria.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 448
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "En la luz del espejo le están cortando el pelo al que yo soy. La gran tijera que recorta el día roza la yugular, roza la nuca con el frío metálico de un arma; y el que yo soy me mira porque sabe, porque tiene al revés…"
 visits = 1674
 popularite = 0.9335663255773755

--- a/content/de-otros/perdida-y-recuperacion-del-pelo.md
+++ b/content/de-otros/perdida-y-recuperacion-del-pelo.md
@@ -20,7 +20,7 @@ tags = [
 [extra]
 legacy_id = 349
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Para luchar contra el pragmatismo y la horrible tendencia a la consecución de fines útiles, mi primo el mayor propugna el procedimiento de sacarse un buen pelo de la cabeza, hacerle un nudo en el medio y dejarlo caer…"
 visits = 13622
 popularite = 0.9495419524668959

--- a/content/de-otros/pies-hermosos.md
+++ b/content/de-otros/pies-hermosos.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 189
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "La mujer que tiene los pies hermosos nunca podrá ser fea mansa suele subirle la belleza por tobillos pantorrillas y muslos demorarse en el pubis que siempre ha estado más alla de todo canon rodear el ombligo como a uno…"
 visits = 14158
 popularite = 0.42146842042158755

--- a/content/de-otros/poema-no-12-de-espantapajaros.md
+++ b/content/de-otros/poema-no-12-de-espantapajaros.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 180
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Se miran, se presienten, se desean, se acarician, se besan, se desnudan, se respiran, se acuestan, se olfatean, se penetran, se chupan, se demudan, se adormecen, despiertan, se iluminan, se codician, se palpan, se…"
 visits = 26616
 popularite = 0.9060940491335622

--- a/content/de-otros/poema.md
+++ b/content/de-otros/poema.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 407
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Tu voz interrumpe el mundo y le da otra palabra. Ahora gira en los silencios del sol. Tiene mares y tu idea del mar es más bella que el mar. Islas que son cuando hablás y se van cuando callás a su isla que se hunde en…"
 visits = 2499
 popularite = 0.35248945171112883

--- a/content/de-otros/pollita-en-fuga.md
+++ b/content/de-otros/pollita-en-fuga.md
@@ -20,7 +20,7 @@ tags = [
 [extra]
 legacy_id = 347
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "No se le notaba. La última vez que Silvina cayó presa –el 5 de mayo pasado – estaba en la cama con su novio, embarazada y desnuda, pero no se le notaba. La brigada bonaerense la encontró a quince cuadras de la Villa…"
 visits = 1697
 popularite = 0.9070598051785029

--- a/content/de-otros/por-el-piso.md
+++ b/content/de-otros/por-el-piso.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 422
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Van por la junta de los baldosones, marchando. Parece una fila recta, pero no. Hay que mirar con atención, una atención que sólo se logra siendo un niño o estando enamorado. Una atención minuciosamente escrutadora de…"
 visits = 542
 popularite = 0.42150966697530967

--- a/content/de-otros/por-eso.md
+++ b/content/de-otros/por-eso.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 258
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "porque yo me desierto y tú me lluvias porque me océano y me balsas porque me otoño y tú me hojas porque me sótano y me alas por eso yo te músico y me músicas por eso yo te potro y tú me frutas y yo te marinero y me…"
 visits = 4952
 popularite = 0.9605241970255376

--- a/content/de-otros/por-que-defiendo-a-maradona.md
+++ b/content/de-otros/por-que-defiendo-a-maradona.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 341
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "En \"La Venganza será terrible\" del lunes 19 de octubre, Alejandro Dolina, ante el mensaje de una oyente, se expidió con vehemencia sobre las declaraciones de Maradona. \"Ingrid Hammer dice: 'Estimado Dolina, ¿ya no…"
 visits = 1789
 popularite = 0.36018891815256276

--- a/content/de-otros/preguntas.md
+++ b/content/de-otros/preguntas.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 93
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Ya que navegas por mi sangre y conoces mis límites y me despiertas en la mitad del día para acostarme en tu recuerdo y eres furia de mi paciencia para mi dime qué diablos hago por qué te necesito quién eres muda sola…"
 visits = 5614
 popularite = 0.9891322522086501

--- a/content/de-otros/promesas-sobre-el-bidet.md
+++ b/content/de-otros/promesas-sobre-el-bidet.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 146
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Por favor no hagas promesas sobre el bidet por favor no me abras más los sobres. Por favor, yo te prometo te escribiré si es que para de correr. Por favor, sigue la sombra de mi bebé, por favor, no bebas más, por favor…"
 visits = 9660
 popularite = 0.9131748810622817

--- a/content/de-otros/puente.md
+++ b/content/de-otros/puente.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 393
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "¿Lejos? Hay un arco tendido que hace viajar la flecha de tu voz. ¿Alto? Hay un ala que rema recta, hacia el sol. De polo a polo a una secreta información. ¿Qué más? Estar alerta para el duro remar; y toda el alma…"
 visits = 546
 popularite = 0.9091874338153906

--- a/content/de-otros/que-hago-ahora.md
+++ b/content/de-otros/que-hago-ahora.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 394
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Dónde pongo lo hallado en las calles, los libros, las noche, los rostros en que te he buscado. Dónde pongo lo hallado en la tierra, en tu nombre, en la Biblia, en el día que al fin te he encontrado. Qué le digo a la…"
 visits = 2254
 popularite = 0.9422720031840343

--- a/content/de-otros/rostro-de-vos.md
+++ b/content/de-otros/rostro-de-vos.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 411
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Tengo una soledad tan concurrida tan llena de nostalgias y de rostros de vos de adioses hace tiempo y besos bienvenidos de primeras de cambio y de último vagón. Tengo una soledad tan concurrida que puedo organizarla…"
 visits = 3477
 popularite = 0.9076700618274073

--- a/content/de-otros/sanar.md
+++ b/content/de-otros/sanar.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 415
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Las lágrimas van al cielo Y vuelven a tus ojos desde el mar El tiempo se va, se va y no vuelve Y tu corazón va a sanar Va a sanar Va a sanar La tierra parece estar quieta Y el sol parece girar, Y aunque parezca mentira…"
 visits = 541
 popularite = 0.9090419688685463

--- a/content/de-otros/si-llega-a-ser-tucumana.md
+++ b/content/de-otros/si-llega-a-ser-tucumana.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 217
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Si la cintura es un junco y la boca es colorada, si son los ojos retintos... esa moza es tucumana. Si es dulce como esa niña y airosa cuando la bailan, si te gana el corazón... esa zamba es tucumana. Y si la moza y la…"
 visits = 44450
 popularite = 0.5425418446065758

--- a/content/de-otros/si-toco-todos-los-dias.md
+++ b/content/de-otros/si-toco-todos-los-dias.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 427
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Si toco todos los días este pan, la cama y mis zapatos el pie que me adelanta y el ojo por donde entra el mundo. Si con esta visión de la corteza adivino al árbol y al pájaro que viene. ¿Cómo no voy a conocer la exacta…"
 visits = 1006
 popularite = 0.35267045909840383

--- a/content/de-otros/sin-senal-de-adios.md
+++ b/content/de-otros/sin-senal-de-adios.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 385
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Qué dulce modo tenés de no estar, quédate así cuando te vas, como un aroma de sol en la piel mucho verano después. Qué melancólico modo tenés de acompañar aunque no estés. Tiembla en el aire del atardecer verte por…"
 visits = 1222
 popularite = 0.35842973978767356

--- a/content/de-otros/soneto-a-tus-visceras.md
+++ b/content/de-otros/soneto-a-tus-visceras.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 178
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Harto ya de alabar tu piel dorada, tus externas y muchas perfecciones, canto al jardín azul de tus pulmones y a tu traquea elegante y anillada. Canto a tu masa intestinal rosada al brazo, al páncreas, a los epiplones…"
 visits = 6114
 popularite = 0.9064331433338957

--- a/content/de-otros/sozinho.md
+++ b/content/de-otros/sozinho.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 216
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Às vezes, no silêncio da noite Eu fico imaginando nós dois Eu fico ali sonhando acordado, juntando O antes, o agora e o depois Por que você me deixa tão solto? Por que você não cola em mim? Tô me sentindo muito…"
 visits = 21956
 popularite = 0.9439521677006377

--- a/content/de-otros/suenero.md
+++ b/content/de-otros/suenero.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 128
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Silbo en la oscuridad animal sin reposo torres de la vigilia candela de los ojos. No sé qué pueda ser si una curva del tiempo o un hueco en el corazón atento . Trigo sobre el brocal para que coma el hambre y abajo el…"
 visits = 5345
 popularite = 0.9070244380093243

--- a/content/de-otros/synecdoche-new-york.md
+++ b/content/de-otros/synecdoche-new-york.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 443
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "A la memoria de Philip Seymour Hoffman Todo es más complicado de lo que piensas. Sólo ves un décimo de lo que es verdad. Hay un millón de pequeños hilos ligados a cada decisión que tomas. Puedes destruir tu vida cada…"
 visits = 1166
 popularite = 0.983059446523208

--- a/content/de-otros/te-doy-una-cancion.md
+++ b/content/de-otros/te-doy-una-cancion.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 204
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Cómo gasto papeles recordándote Cómo me haces hablar en el silencio Y cómo no te me quitas de las ganas Aunque nadie me vea nunca contigo Y cómo pasa el tiempo Que de pronto son años Sin pasar tú por mí Detenida Te doy…"
 visits = 780
 popularite = 0.9045912332169311

--- a/content/de-otros/teologa.md
+++ b/content/de-otros/teologa.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 271
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "En el siglo Vll después de Cristo, un grupo de teólogos bávaros discute sobre el sexo de los ángeles. Obviamente, no se admite que las mujeres (por entonces ni siquiera era seguro que tuvieran alma) sean capaces de…"
 visits = 2724
 popularite = 0.4270365568177682

--- a/content/de-otros/tocar-a-gimena.md
+++ b/content/de-otros/tocar-a-gimena.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 323
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Lo primero que me trae a la mente la palabra \"tocar\" es mi amiga Gimena, compañera de colegio, en el viaje de egresados, el último año de la secundaria. Y más específicamente el ómnibus que nos llevaba de vuelta al…"
 visits = 0
 popularite = 0.0

--- a/content/de-otros/torito.md
+++ b/content/de-otros/torito.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 248
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Qué le vas a hacer, ñato, cuando estás abajo todos te fajan. Todos, che, hasta el más maula. Te sacuden contra las sogas, te encajan la biaba. Andá, andá, qué venís con consuelos vos. Te conozco, mascarita. Cada vez…"
 visits = 9398
 popularite = 0.9063558860227122

--- a/content/de-otros/tu-laberinto.md
+++ b/content/de-otros/tu-laberinto.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 417
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Cuando quieras mi amor, no lo imagines no sueñes esperando que lo adivine Cuando quieras al fin seguir tu instinto ven a verme y abandona tu laberinto Si no entiendes lo que vives, si no crees lo que dicen, Quizas sea…"
 visits = 0
 popularite = 0.0

--- a/content/de-otros/tu-nombre.md
+++ b/content/de-otros/tu-nombre.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 391
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Trato de escribir en la oscuridad tu nombre. Trato de escribir que te amo. Trato de decir a oscuras esto. No quiero que nadie se entere, que nadie me mire a las tres de la mañana, paseando a lo largo de la estancia…"
 visits = 1273
 popularite = 0.9041542274460466

--- a/content/de-otros/ultima-empresa.md
+++ b/content/de-otros/ultima-empresa.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 107
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Las ideas las tenía yo, ella las ponía en práctica. En general a mí las ideas se me ocurrían cuando espantaba recuerdos o cuando sentado a mi escritorio de ideas jugueteaba con la réplica del puñal de Sandokán, o…"
 visits = 1547
 popularite = 0.2505558817611528

--- a/content/de-otros/un-ruisenor-en-concierto.md
+++ b/content/de-otros/un-ruisenor-en-concierto.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 426
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "En la cima del árbol justo al borde del verde -en donde empieza el aire- hay un ruiseñor en concierto. Por un momento creo que soy de nube que no me pesa esta materia que casi tengo la altura de su canto. De pronto el…"
 visits = 784
 popularite = 0.9095423822711809

--- a/content/de-otros/un-sueno.md
+++ b/content/de-otros/un-sueno.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 177
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "En un desierto lugar del Irán hay una no muy alta torre de piedra, sin puerta ni ventana. En la única habitación (cuyo piso es de tierra y que tiene la forma del círculo) hay una mesa de madera y un banco. En esa celda…"
 visits = 14197
 popularite = 0.6786000819473098

--- a/content/de-otros/una-carta-de-amor.md
+++ b/content/de-otros/una-carta-de-amor.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 123
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Todo lo que de vos quisiera es tan poco en el fondo porque en el fondo es todo, como un perro que pasa, una colina, esas cosas de nada, cotidianas, espiga y cabellera y dos terrones, el olor de tu cuerpo, lo que decís…"
 visits = 28877
 popularite = 0.9103697183727175

--- a/content/de-otros/una-modesta-proposicion.md
+++ b/content/de-otros/una-modesta-proposicion.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 279
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Para prevenir que los niños de los pobres de Irlanda sean una carga para sus padres o el país, y para hacerlos útiles al público Dublín, Irlanda, 1729 Es un asunto melancólico para quienes pasean por esta gran ciudad o…"
 visits = 1279
 popularite = 0.9071164913818109

--- a/content/de-otros/una-mujer-y-un-hombre.md
+++ b/content/de-otros/una-mujer-y-un-hombre.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 218
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Una mujer y un hombre llevados por la vida, una mujer y un hombre cara a cara habitan en la noche, desbordan por sus manos, se oyen subir libres en la sombra, sus cabezas descansan en una bella infancia que ellos…"
 visits = 4487
 popularite = 0.9387650994300958

--- a/content/de-otros/uno-nunca-sabe.md
+++ b/content/de-otros/uno-nunca-sabe.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 246
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Lo primero que le preguntó Mario apenas el Mochila se sentó, fue \"¿La conoces a esa mina?\". -- ¿Cuál? -- La que saludastes recién. Mochila giró apenas la cabeza hacia atrás. -- ¿La flaca? -- Sí. -- Sí, la conozco. Es…"
 visits = 9995
 popularite = 0.9045439066782933

--- a/content/de-otros/veinte-minutos.md
+++ b/content/de-otros/veinte-minutos.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 357
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Papá nunca deja rastros. Incluso ahora, que trataba de evitar el mal humor durmiendo, está tirado sin desarmar la cama. Hace un rato le gritó a mamá desde el pasillo: --Lilí, llamame en veinte minutos. Papá puede…"
 visits = 3133
 popularite = 0.9438263225838504

--- a/content/de-otros/veneno.md
+++ b/content/de-otros/veneno.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 410
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Se puede decir que entré en la literatura por un ascensor. Me explico: cuando tenía quince, un vecino de mi edificio nos oyó hablar a mis amigos y a mí en un viaje en ascensor, y nos invitó a su departamento en el…"
 visits = 0
 popularite = 0.0

--- a/content/de-otros/verde-y-azul-325.md
+++ b/content/de-otros/verde-y-azul-325.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 325
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Ella es el verde y yo el azul. Y cuando estamos azul sobre verde somos la tierra y el cielo, porque ella es la ofrenda fértil y yo soy los vientos con tormentas y soles; porque ella es la risa, el pan, la tierra y yo…"
 visits = 0
 popularite = 0.0

--- a/content/de-otros/verde-y-azul.md
+++ b/content/de-otros/verde-y-azul.md
@@ -16,7 +16,7 @@ tags = []
 [extra]
 legacy_id = 263
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Ella es el verde y yo el azul. Y cuando estamos azul sobre verde somos la tierra y el cielo, porque ella es la ofrenda fértil y yo soy los vientos con tormentas y soles; porque ella es la risa, el pan, la tierra y yo…"
 visits = 0
 popularite = 0.0

--- a/content/de-otros/viento-sur.md
+++ b/content/de-otros/viento-sur.md
@@ -19,7 +19,7 @@ tags = [
 [extra]
 legacy_id = 383
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "No hay tunel que dure cien años, mi vida. Mira como se arruga la tiniebla, la procesión de pálidas se desbarranca, los funcionarios inauguran ruinas. Y vos y yo fundamos aires buenos. Donde estará la plata de mi río…"
 visits = 4214
 popularite = 0.2503866625464238

--- a/content/de-otros/y-el-amor.md
+++ b/content/de-otros/y-el-amor.md
@@ -18,7 +18,7 @@ tags = [
 [extra]
 legacy_id = 108
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "El milagro de existir, el instinto de buscar, la fortuna de encontrar, el gusto de conocer. La ilusión de vislumbrar, el placer de coincidir, el temor a reincidir, el orgullo de gustar. La emoción de desnudar y…"
 visits = 5139
 popularite = 0.5645960787306027

--- a/content/de-otros/zamba-de-usted.md
+++ b/content/de-otros/zamba-de-usted.md
@@ -20,7 +20,7 @@ tags = [
 [extra]
 legacy_id = 381
 section_slug = "de-otros"
-section_title = "De otros"
+section_title = "De otres"
 summary = "Yo no sé si podrá esta zamba llegar a usted, bajo los luceros va por la noche buscando el pueblito donde la dejé Por oir otra vez la tonadita de su voz, niña de los ojos color de olivo me iré tras la zamba, romero de…"
 visits = 2242
 popularite = 0.9075009308418274

--- a/scripts/new_article.py
+++ b/scripts/new_article.py
@@ -15,7 +15,7 @@ SECTION_TITLES = {
     "blog": "Blog",
     "fotos": "Fotos",
     "videos": "Videos",
-    "de-otros": "De otros",
+    "de-otros": "De otres",
     "personal": "Personal",
 }
 

--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -203,7 +203,7 @@ function sectionMetaFromPath(pathname) {
   const sectionSlug = pathname.split("/").filter(Boolean)[0] || "";
   const sectionTitles = {
     blog: "Blog",
-    "de-otros": "De otros",
+    "de-otros": "De otres",
     fotos: "Fotos",
     videos: "Videos",
     personal: "Personal",


### PR DESCRIPTION
## Summary

- Actualiza `title = "De otres"` en `content/de-otros/_index.md`
- Reemplaza `section_title = "De otros"` → `"De otres"` en los 170 artículos de la sección
- Corrige el mapa `sectionTitles` en `site.js` (usado en comentarios recientes dinámicos)

Las URLs `/de-otros/` no cambian para no romper links existentes. El PR #76 había corregido la nav y los ribbons pero quedaron pendientes los títulos de la sección y los artículos.

## Test plan

- [ ] Verificar que `/de-otros/` muestra "De otres" como título de la sección
- [ ] Verificar que el kicker de cada artículo de la sección dice "De otres"
- [ ] Verificar que en home sidebar el ribbon/kicker dice "De otres"

🤖 Generated with [Claude Code](https://claude.com/claude-code)