### PR TITLE
feat: report links for comment moderation (#42)

### DIFF
--- a/.github/ISSUE_TEMPLATE/moderar_comentario.yml
+++ b/.github/ISSUE_TEMPLATE/moderar_comentario.yml
@@ -1,0 +1,61 @@
+name: Moderar comentario
+description: Reportar spam o pedir moderación de un comentario del sitio
+labels: ["comentarios"]
+body:
+  - type: dropdown
+    id: accion
+    attributes:
+      label: Acción sugerida
+      description: Qué te gustaría que se haga con el comentario
+      options:
+        - Revisar
+        - Ocultar
+        - Marcar como spam
+    validations:
+      required: true
+  - type: input
+    id: article_url
+    attributes:
+      label: URL del artículo
+      description: Página donde aparece el comentario
+      placeholder: "https://textosypretextos.com.ar/..."
+    validations:
+      required: true
+  - type: input
+    id: comment_url
+    attributes:
+      label: URL del comentario
+      description: Link directo al comentario
+      placeholder: "https://textosypretextos.com.ar/...#comment-123"
+    validations:
+      required: true
+  - type: input
+    id: article_slug
+    attributes:
+      label: Slug del artículo
+      placeholder: "mi-articulo"
+    validations:
+      required: true
+  - type: input
+    id: comment_id
+    attributes:
+      label: ID del comentario
+      placeholder: "123"
+    validations:
+      required: true
+  - type: input
+    id: source
+    attributes:
+      label: Fuente
+      description: Ruta del archivo fuente del artículo
+      placeholder: "content/blog/..."
+    validations:
+      required: false
+  - type: textarea
+    id: motivo
+    attributes:
+      label: Motivo
+      description: Explicá por qué querés reportar o moderar este comentario
+      placeholder: "Spam, insulto, link malicioso, doxxing, etc."
+    validations:
+      required: true

--- a/src/scripts/site.js
+++ b/src/scripts/site.js
@@ -142,6 +142,20 @@ function formatDate(unixSeconds) {
   return d.toLocaleDateString("es-AR", { year: "numeric", month: "2-digit", day: "2-digit" });
 }
 
+function buildCommentReportUrl({ baseUrl, articleUrl, articleSlug, sourcePath, commentId }) {
+  if (!baseUrl || !articleUrl || !articleSlug || !commentId) return "";
+  const url = new URL(baseUrl);
+  url.searchParams.set("title", `moderar comentario ${commentId} en ${articleSlug}`);
+  url.searchParams.set("article_url", articleUrl);
+  url.searchParams.set("comment_url", `${articleUrl}#comment-${commentId}`);
+  url.searchParams.set("article_slug", articleSlug);
+  url.searchParams.set("comment_id", String(commentId));
+  if (sourcePath) {
+    url.searchParams.set("source", sourcePath);
+  }
+  return url.toString();
+}
+
 async function loadDynamicComments(container, slug) {
   try {
     const res = await fetch(`/api/comments?slug=${encodeURIComponent(slug)}`, {
@@ -151,16 +165,33 @@ async function loadDynamicComments(container, slug) {
     const data = await res.json();
     const list = (data && data.comments) || [];
     if (!list.length) return;
+    const commentsSection = document.getElementById("comments");
+    const reportBase = commentsSection?.dataset.commentReportBase || "";
+    const articleUrl = commentsSection?.dataset.commentReportArticleUrl || window.location.href.split("#")[0];
+    const articleSlug = commentsSection?.dataset.commentReportArticleSlug || slug;
+    const sourcePath = commentsSection?.dataset.commentReportSource || "";
     document.getElementById("no-comments-placeholder")?.remove();
-    const html = list.map((c) => `
-      <article class="comment-card" data-depth="0">
+    const html = list.map((c) => {
+      const reportUrl = buildCommentReportUrl({
+        baseUrl: reportBase,
+        articleUrl,
+        articleSlug,
+        sourcePath,
+        commentId: c.id,
+      });
+      return `
+      <article class="comment-card" data-depth="0" id="comment-${c.id}">
         <div class="meta-row">
           <span>${escapeHtml(c.author || "Anónimo")}</span>
-          <span>${formatDate(c.created_at)}</span>
+          <div class="comment-meta-actions">
+            <span>${formatDate(c.created_at)}</span>
+            ${reportUrl ? `<a class="comment-report-link" href="${reportUrl}" rel="noopener" target="_blank">Reportar</a>` : ""}
+          </div>
         </div>
         <div class="comment-body">${escapeHtml(c.body).replace(/\n/g, "<br>")}</div>
       </article>
-    `).join("");
+    `;
+    }).join("");
     container.innerHTML = html;
   } catch (_e) {
     // Silent: comment loading failure shouldn't break the page.

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -550,6 +550,15 @@
     @apply border-b border-black py-5;
   }
 
+  .comment-meta-actions {
+    @apply flex items-center gap-3 text-right;
+  }
+
+  .comment-report-link {
+    font-family: var(--font-ui);
+    @apply text-[11px] uppercase tracking-[0.18em] text-neutral-500 hover:text-black;
+  }
+
   .no-comments-placeholder {
     @apply py-6 text-neutral-500 text-sm italic;
   }

--- a/templates/article.html
+++ b/templates/article.html
@@ -96,7 +96,21 @@
       </nav>
     {% endif %}
 
-    <section id="comments" class="comment-list reveal">
+    {% if config.extra.github_repo and page.relative_path %}
+      {% set comment_issue_base = "https://github.com/" ~ config.extra.github_repo ~ "/issues/new?template=moderar_comentario.yml" %}
+      {% set comment_source_path = "content/" ~ page.relative_path %}
+    {% endif %}
+
+    <section
+      id="comments"
+      class="comment-list reveal"
+      {% if comment_issue_base %}
+        data-comment-report-base="{{ comment_issue_base }}"
+        data-comment-report-article-url="{{ page.permalink }}"
+        data-comment-report-article-slug="{{ page.slug }}"
+        data-comment-report-source="{{ comment_source_path }}"
+      {% endif %}
+    >
       <div class="pt-8">
         <span class="section-ribbon">Comentarios</span>
       </div>
@@ -107,7 +121,26 @@
             <article class="comment-card" id="{{ comment.anchor }}" data-depth="{{ comment.depth }}">
               <div class="meta-row">
                 <span>{{ comment.author | default(value="Anónimo") }}</span>
-                <span>{{ comment.date_display }}</span>
+                <div class="comment-meta-actions">
+                  <span>{{ comment.date_display }}</span>
+                  {% if comment_issue_base and comment.id %}
+                    {% set comment_issue_title_raw = "moderar comentario " ~ comment.id ~ " en " ~ page.slug %}
+                    {% set comment_issue_title = comment_issue_title_raw | urlencode %}
+                    {% set comment_url_raw = page.permalink ~ "#" ~ comment.anchor %}
+                    {% set comment_url = comment_url_raw | urlencode %}
+                    {% set comment_source = comment_source_path | urlencode %}
+                    {% set comment_article_url = page.permalink | urlencode %}
+                    {% set comment_article_slug = page.slug | urlencode %}
+                    {% set report_url = comment_issue_base
+                      ~ "&title=" ~ comment_issue_title
+                      ~ "&article_url=" ~ comment_article_url
+                      ~ "&comment_url=" ~ comment_url
+                      ~ "&article_slug=" ~ comment_article_slug
+                      ~ "&comment_id=" ~ comment.id
+                      ~ "&source=" ~ comment_source %}
+                    <a href="{{ report_url }}" class="comment-report-link" rel="noopener" target="_blank">Reportar</a>
+                  {% endif %}
+                </div>
               </div>
               <div class="comment-body">{{ comment.body | escape | replace(from="\n", to="<br>") | safe }}</div>
             </article>


### PR DESCRIPTION
Closes #42

## Qué cambia
- agrega un issue form específico para moderación de comentarios
- agrega link `Reportar` en cada comentario estático
- agrega link `Reportar` en cada comentario dinámico cargado desde D1
- precarga artículo, permalink del comentario, slug e id del comentario para facilitar moderación rápida
- deja el flujo apoyado en GitHub, sin borrado automático todavía

## Validación
- la UI compila en assets
- intenté `npm run build`, pero hoy falla por un problema ajeno en `author.html`: `page.extra.gender` faltante en `content/autores/roberto-juarroz.md`
