### PR TITLE
fix: remove obvious static comment spam (#219)

### DIFF
--- a/content/de-otros/no-te-rindas.md
+++ b/content/de-otros/no-te-rindas.md
@@ -25,7 +25,7 @@ visits = 1682970
 popularite = 0.9241870534400456
 hero_image = ""
 hero_alt = ""
-comment_count = 105
+comment_count = 98
 legacy_url = "/de-otros/no-te-rindas/"
 surtitle = ""
 subtitle = "Mario Benedetti"
@@ -665,16 +665,6 @@ url_site = ""
 title = "No te rindas"
 body = "Hola,este poema me lleno el alma,llego a mi vida el día mas triste de toda mi existencia,acababa de partir mi esposo el mismo día de nuestro aniversario, 29 anos de casados, sufrió una muerte súbita,mis hijos me la regalaron ,cuando estoy muy triste la releo una y mil veces es lo mejor que he leído gracias"
 
-[[extra.comments]]
-id = 53191
-anchor = "comment-53191"
-author = "Sonia"
-date = "2012-07-19 11:15:11"
-date_display = "19.07.2012"
-depth = 0
-url_site = ""
-title = "No te rindas"
-body = "Votre article est excellant, cependant il y a un bug, je n'arrive pas afficher les images ? Peut être c'est mon navigateur qui ne marche pas bien ? (J'utilise Google Chrome)\nEn tout les cas je reviendrai vous lire :)\n\n<div style=\"display:none;\">\n	<h1>Quel est la meilleure mutuelle ASAF</h1> <h2>Quelle est la meilleure mutuelle santé</h2> [mutuelle jeune](http://www.chu-mutuelle.fr) pour chercher une mutuelle pas cher et trouver la mutuelle pour jeune selon les attentes de chacun d'entre nous  avec changement de mutuelle familiale </div>"
 
 [[extra.comments]]
 id = 53200
@@ -819,38 +809,8 @@ url_site = ""
 title = "No te rindas"
 body = "grasias a este poema esta muy lindo me agrada el poema de benedetti yo se lo di a un amigo que se fracturo la mano"
 
-[[extra.comments]]
-id = 53461
-anchor = "comment-53461"
-author = "mutuelle-conseil"
-date = "2012-10-12 11:55:20"
-date_display = "12.10.2012"
-depth = 0
-url_site = "http://www.mutuelle-conseil.com"
-title = "No te rindas"
-body = "Muchas gracias"
 
-[[extra.comments]]
-id = 53471
-anchor = "comment-53471"
-author = "nadege"
-date = "2012-10-16 11:29:31"
-date_display = "16.10.2012"
-depth = 0
-url_site = ""
-title = "No te rindas"
-body = "Quel beau texte. Bravo\n[université de la cartouche](http://univ-cartouche.fr/)"
 
-[[extra.comments]]
-id = 53472
-anchor = "comment-53472"
-author = "richard"
-date = "2012-10-16 12:34:40"
-date_display = "16.10.2012"
-depth = 0
-url_site = ""
-title = "No te rindas"
-body = "Simplement magnifique.\n[Visites Guidées Paris](http://ac-visiter.fr/)"
 
 [[extra.comments]]
 id = 53513
@@ -896,16 +856,6 @@ url_site = ""
 title = "No te rindas"
 body = "me gusto el poema de Mario Benedetti por que expresa todos sus sentimientos"
 
-[[extra.comments]]
-id = 53622
-anchor = "comment-53622"
-author = "Enrico"
-date = "2012-12-14 12:27:30"
-date_display = "14.12.2012"
-depth = 0
-url_site = "http://www;ambiance-thalasso.com/"
-title = "No te rindas"
-body = "Magnifique texte !"
 
 [[extra.comments]]
 id = 53631
@@ -951,16 +901,6 @@ url_site = ""
 title = "No te rindas"
 body = "Si es de Benedetti y está incompleto."
 
-[[extra.comments]]
-id = 54096
-anchor = "comment-54096"
-author = "Maria"
-date = "2013-01-08 10:38:50"
-date_display = "08.01.2013"
-depth = 0
-url_site = ""
-title = "No te rindas"
-body = "Gracias por todo este trabajo de fondo, no siempre es fácil\n<div style=\"display:none;\">\n<h2>[La Guadeloupe](www.1location-guadeloupe.fr/la-guadeloupe/)</h2>\n</div>"
 
 [[extra.comments]]
 id = 54097
@@ -973,16 +913,6 @@ url_site = ""
 title = "No te rindas"
 body = "Que extraordinario poema .\nMi madre me lo mandó tiene 85 años y me lo manda para las almas jóvenes y tristes que ironia verdad?\n\nElla con una alegria a prueba de muertes, refugios, cárceles y tantas otras cosas\ncreo que el poema ella lo representa de forma admirable\n\nEchemole ganas a la vida vale la pena\nBravo Mario y Gracias Madre"
 
-[[extra.comments]]
-id = 54105
-anchor = "comment-54105"
-author = "Julia"
-date = "2013-01-13 11:03:42"
-date_display = "13.01.2013"
-depth = 0
-url_site = ""
-title = "No te rindas"
-body = "Este blog en particular es realmente educar y divertido también. He elegido muchas cosas útiles de este blog. \n<div style=\"position:relative;left:-7842px;height:5px ;\"><h2>Locations de véhicules sur l'île de la  Guadeloupe</h2>\n[Officiel Auto Guadeloupe](www.ac-locationvoitureguadeloupe.fr/)\n[voiture en location Guadeloupe](http://location-voiture.guadeloupe-guadeloupe.fr/)\n[locations voitures Antilles Guadeloupe](http://univ-location-voiture-guadeloupe.fr/)\n[1locationvoitureguadeloupe.fr](http://1locationvoitureguadeloupe.fr/)\n[locationdevoiture-971.fr](www.locationdevoiture-971.fr/)\n</div>"
 
 [[extra.comments]]
 id = 54114

--- a/content/fotos/as-criancas.md
+++ b/content/fotos/as-criancas.md
@@ -22,7 +22,7 @@ visits = 2244
 popularite = 0.9473996498843157
 hero_image = "/media/jpg/DSC_1844.jpg"
 hero_alt = "DSC_1844.jpg"
-comment_count = 2
+comment_count = 1
 legacy_url = "/fotos/as-criancas/"
 surtitle = ""
 subtitle = ""
@@ -43,16 +43,6 @@ url_site = ""
 title = "As crianças"
 body = "Que buenas fotos!! No me acordaba que las tenias, muy lindas.\nViendo esas sonrisas pienso que lo que hacemos es una forma de defender la alegría, no? \n\n\"Defender la alegría como un derecho\ndefenderla de dios y del invierno\nde las mayúsculas y de la muerte\nde los apellidos y las lástimas\ndel azar\ny también de la alegría.\"\n\nLa dejo picando, je...\nUn abrazo cumpa..."
 
-[[extra.comments]]
-id = 53697
-anchor = "comment-53697"
-author = "jwJKPbEmALaX"
-date = "2012-12-25 21:23:13"
-date_display = "25.12.2012"
-depth = 0
-url_site = "http://www.facebook.com/profile.php?id=100003407203729"
-title = "As crianças"
-body = "a1a1Genial el poster del edicfiio!! Sin duda la peledcula me1s esperada del af1o junto a la de Indiana. Luego de la muerte de Heath Ledger se dijo que la Warner no seguireda usando su imagen para promocionar el film, para no despertar el morbo. Veo, con agrado, que no ha sido ased. Resaltar su guasf3n como su faltimo gran papel es el mejor homenaje que se le puede hacer al buen Heath."
 +++
 
 Fotos tomadas el 6 de septiembre de 2008, en una de las actividades de [Mazamorra](http://www.agrupacionmazamorra.com.ar)

--- a/content/fotos/colores.md
+++ b/content/fotos/colores.md
@@ -25,7 +25,7 @@ visits = 578
 popularite = 0.9173714248876832
 hero_image = "/media/jpg/DSC_0008.jpg"
 hero_alt = "DSC_0008.jpg"
-comment_count = 3
+comment_count = 1
 legacy_url = "/fotos/colores/"
 surtitle = ""
 subtitle = ""
@@ -49,27 +49,6 @@ url_site = "http://www.elblogdesandra.blogspot.com"
 title = "Colores"
 body = "Es de la verdulería que está sobre Santiago Temple y Psje Turrado Juarez? yo amo esa verdulería, el dueño se llama Juan y tiene muy buenos precios, ah te recomiendo la despensa de los jujeños y la de la Gladys, sobre la Velez.\n(snif snif yo vivia ahi).\nBesos"
 
-[[extra.comments]]
-id = 54211
-anchor = "comment-54211"
-author = "jEfrwSdmYgSMUTmsv"
-date = "2013-02-19 01:29:20"
-date_display = "19.02.2013"
-depth = 0
-url_site = "http://www.facebook.com/profile.php?id=100003412057717"
-title = "Colores"
-body = "I feel like you could probably teach a class on how to make a great blog. This is faistatnc! I have to say, what really got me was your design. You certainly know how to make your blog more than just a rant about an issue. Youve made it possible for people to connect. Good for you, because not that many people know what theyre doing. Some truly superb information and very useful various hair loss treatment."
-
-[[extra.comments]]
-id = 54225
-anchor = "comment-54225"
-author = "TDRYVWROaPFpzlMdH"
-date = "2013-02-19 03:57:18"
-date_display = "19.02.2013"
-depth = 0
-url_site = "http://www.facebook.com/profile.php?id=100003412266506"
-title = "Colores"
-body = "Le 11/01/2011 e0 22h33                    \"On aura le plaisir de rievor la gentille Karine Le Marchand balader son dressing aux quatre coins de la France...\" haha c'est trop vrai !"
 +++
 
 Fotografías tomadas en Barrio Güemes, Córdoba, una mañana con mi amigo y compañero Agus.

--- a/content/fotos/cronica-de-un-intento-de-homenaje.md
+++ b/content/fotos/cronica-de-un-intento-de-homenaje.md
@@ -25,7 +25,7 @@ visits = 5923
 popularite = 0.9125278969859208
 hero_image = "/media/jpg/DSC_0020.jpg"
 hero_alt = "Cursilerías de otoño 1"
-comment_count = 1
+comment_count = 0
 legacy_url = "/fotos/cronica-de-un-intento-de-homenaje/"
 surtitle = ""
 subtitle = ""
@@ -38,16 +38,6 @@ tag_links = [
     { name = "Memoria", path = "/etiquetas/memoria/" },
 ]
 
-[[extra.comments]]
-id = 54310
-anchor = "comment-54310"
-author = "xsxpCRyWHGCd"
-date = "2013-02-21 07:59:12"
-date_display = "21.02.2013"
-depth = 0
-url_site = "http://www.facebook.com/profile.php?id=100003411213472"
-title = "Crónica de un intento de homenaje"
-body = "Estaba rebuscando este antsuo en particular mediante el uso de ask cuando me tope9 con su web. Tienes una gran cantidad de tema genial aqued. Sin duda una de mis favoritas."
 +++
 
 *Rosario, entre el 13 y el 16 de junio de 2008*

--- a/content/fotos/la-perla.md
+++ b/content/fotos/la-perla.md
@@ -25,7 +25,7 @@ visits = 2621
 popularite = 0.9843284392200226
 hero_image = "/media/jpg/DSC_0005.jpg"
 hero_alt = "DSC_0005.jpg"
-comment_count = 4
+comment_count = 3
 legacy_url = "/fotos/la-perla/"
 surtitle = ""
 subtitle = ""
@@ -71,16 +71,6 @@ url_site = ""
 title = "La Perla"
 body = "la foto de las rosas me conmovió\nmuchas gracias\n\nDaniela"
 
-[[extra.comments]]
-id = 53680
-anchor = "comment-53680"
-author = "qcVyXhRVIHHGlNybx"
-date = "2012-12-25 15:56:37"
-date_display = "25.12.2012"
-depth = 0
-url_site = "http://www.facebook.com/profile.php?id=100003407223104"
-title = "La Perla"
-body = "Como bien dices todo radica en el prpoio autoconvencimiento de las cosas, a partir de ahi todo lo deme1s este1 por ver, pero desde luego que si no partes de esa base desde un primer momento pues mal lo llevas.En Revolutionary Road ademe1s de influir el hecho de conseguir o no un suef1o tb se marca mucho el tema de la perspectiva que se tiene sobre los deme1s, la imagen o la opinif3n que la gente marca o da sobre el resto. \"es una mierda eso de ir aparentando cosas por al mundo adelante, siempre lo dije\"En fin, esto por poner algo, como es la primera vez que entro aqui... (Abraham)Mira Slumdog Millionaire que es me1s entretenida :P"
 +++
 
 Fotos del Acto de Recuperación de *[La Perla](http://www.desaparecidos.org/arg/conadep/nuncamas/202.html)*, Córdoba, Sábado 24 de marzo de 2007. Publicadas originalmente [aquí](http://derechoshumanoscba.org.ar/spip.php?article434).

--- a/scripts/find_static_comment_spam.py
+++ b/scripts/find_static_comment_spam.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env -S uv run python
+# /// script
+# requires-python = ">=3.11"
+# ///
+"""Detect obvious spam candidates in static frontmatter comments."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import tomllib
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+RE_FRONTMATTER = re.compile(r"^\+\+\+\n(.*?)\n\+\+\+\n?", re.DOTALL)
+RE_RANDOM_AUTHOR = re.compile(r"^(?=.*[a-z])(?=.*[A-Z])[A-Za-z]{12,}$")
+RE_LINK = re.compile(r"https?://|www\.", re.IGNORECASE)
+
+SPAM_MARKERS = [
+    "display:none",
+    "position:relative;left:-",
+    "hair loss treatment",
+    "mutuelle",
+    "guadeloupe",
+    "visites guidées",
+    "université de la cartouche",
+    "facebook.com/profile.php?id=",
+]
+
+FOREIGN_MARKERS = [
+    "i feel like you could probably teach a class",
+    "quel beau texte",
+    "simplement magnifique",
+    "votre article est excellant",
+    "locations de véhicules",
+]
+
+
+def parse_frontmatter(path: pathlib.Path) -> dict:
+    text = path.read_text(encoding="utf-8")
+    match = RE_FRONTMATTER.match(text)
+    if not match:
+        return {}
+    return tomllib.loads(match.group(1))
+
+
+def detect_reasons(comment: dict) -> list[str]:
+    reasons: list[str] = []
+    author = str(comment.get("author", "")).strip()
+    body = str(comment.get("body", "")).strip().lower()
+    url_site = str(comment.get("url_site", "")).strip().lower()
+
+    if author and RE_RANDOM_AUTHOR.match(author):
+        reasons.append("author-random")
+    if url_site and "facebook.com/profile.php?id=" in url_site and reasons:
+        reasons.append("fb-profile")
+
+    if any(marker in body for marker in SPAM_MARKERS):
+        reasons.append("seo-marker")
+    if any(marker in body for marker in FOREIGN_MARKERS):
+        reasons.append("foreign-template")
+
+    body_link_count = len(RE_LINK.findall(body))
+    if body_link_count >= 2 and ("seo-marker" in reasons or "foreign-template" in reasons):
+        reasons.append("many-links")
+    elif body_link_count >= 1 and ("seo-marker" in reasons or "foreign-template" in reasons):
+        reasons.append("promo-link")
+
+    if author.lower() in {"mutuelle-conseil"}:
+        reasons.append("spam-author")
+
+    return reasons
+
+
+def resolve_paths(args: list[str]) -> list[pathlib.Path]:
+    if args:
+        return [(ROOT / arg).resolve() if not pathlib.Path(arg).is_absolute() else pathlib.Path(arg) for arg in args]
+    return sorted((ROOT / "content").rglob("*.md"))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="*", help="Archivos a revisar (default: content/**/*.md)")
+    opts = parser.parse_args()
+
+    total = 0
+    for path in resolve_paths(opts.paths):
+        if not path.exists() or path.suffix != ".md":
+            continue
+        data = parse_frontmatter(path)
+        comments = (((data.get("extra") or {}).get("comments")) or [])
+        for comment in comments:
+            reasons = detect_reasons(comment)
+            if not reasons:
+                continue
+            total += 1
+            print(
+                f"{path.relative_to(ROOT)} "
+                f"comment_id={comment.get('id')} "
+                f"author={comment.get('author', '')!r} "
+                f"reasons={','.join(reasons)}"
+            )
+    print(f"\nTotal candidatos: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/templates/article.html
+++ b/templates/article.html
@@ -101,9 +101,10 @@
         <span class="section-ribbon">Comentarios</span>
       </div>
 
-      {% if page.extra.comments | length > 0 %}
+      {% set static_comments = page.extra.comments | default(value=[]) %}
+      {% if static_comments | length > 0 %}
         <div class="comments-existing">
-          {% for comment in page.extra.comments %}
+          {% for comment in static_comments %}
             <article class="comment-card" id="{{ comment.anchor }}" data-depth="{{ comment.depth }}">
               <div class="meta-row">
                 <span>{{ comment.author | default(value="Anónimo") }}</span>


### PR DESCRIPTION
Closes #219

## Qué cambia
- elimina una primera tanda de 11 comentarios estáticos que son spam obvio
- ajusta `comment_count` en los artículos afectados
- agrega `scripts/find_static_comment_spam.py` para detectar candidatos con heurísticas conservadoras
- hace más robusto `templates/article.html` cuando un artículo no tiene `extra.comments`

## Limpieza incluida
- `content/fotos/colores.md`: 2 comentarios spam
- `content/fotos/as-criancas.md`: 1 comentario spam
- `content/fotos/la-perla.md`: 1 comentario spam
- `content/fotos/cronica-de-un-intento-de-homenaje.md`: 1 comentario spam
- `content/de-otros/no-te-rindas.md`: 7 comentarios spam SEO/ocultos

## Validación
- `python3 scripts/find_static_comment_spam.py`
- `npm run build`
