### PR TITLE
fix: meta tags Open Graph completos en sección, tags y autores

### DIFF
--- a/templates/authors_index.html
+++ b/templates/authors_index.html
@@ -1,33 +1,46 @@
-{% extends "base.html" %}
-
-{% block title %}Autoras y autores · {{ config.title }}{% endblock title %}
-{% block canonical_url %}{{ section.permalink }}{% endblock canonical_url %}
-{% block og_url %}{{ section.permalink }}{% endblock og_url %}
-
-{% block content %}
-  <main class="pt-8">
+{% extends "base.html" %} {% block title %}Autoras y autores · {{ config.title
+}}{% endblock title %} {% block canonical_url %}{{ section.permalink }}{%
+endblock canonical_url %} {% block og_url %}{{ section.permalink }}{% endblock
+og_url %} {% block og_title %}Autoras y autores · {{ config.title }}{% endblock
+og_title %} {% block og_description %}{{ config.description }}{% endblock
+og_description %} {% block twitter_title %}Autoras y autores · {{ config.title
+}}{% endblock twitter_title %} {% block twitter_description %}{{
+config.description }}{% endblock twitter_description %} {% block content %}
+<main class="pt-8">
     <section class="editorial-rule">
-      <span class="section-ribbon">Autoras y autores</span>
-      <div class="mt-5 max-w-[48rem]">
-        <h2 class="story-title">Autoras y autores</h2>
-      </div>
+        <span class="section-ribbon">Autoras y autores</span>
+        <div class="mt-5 max-w-[48rem]">
+            <h2 class="story-title">Autoras y autores</h2>
+        </div>
     </section>
 
     <section class="taxonomy-grid mt-10">
-      {% for page in section.pages | sort(attribute="title") %}
-        {% if not page.extra.is_owner %}
-          <article class="taxonomy-card reveal">
+        {% for page in section.pages | sort(attribute="title") %} {% if not
+        page.extra.is_owner %}
+        <article class="taxonomy-card reveal">
             {% if page.extra.image %}
-              <a href="{{ page.permalink }}" class="author-thumb">
-                <img src="{{ page.extra.image }}" alt="{{ page.title }}" loading="lazy">
-              </a>
+            <a href="{{ page.permalink }}" class="author-thumb">
+                <img
+                    src="{{ page.extra.image }}"
+                    alt="{{ page.title }}"
+                    loading="lazy"
+                />
+            </a>
             {% endif %}
-            <p class="story-kicker">{% if page.extra.gender | default(value="m") == "f" %}Autora{% else %}Autor{% endif %}</p>
-            <h2 class="story-title-xs"><a href="{{ page.permalink }}">{{ page.title }}</a></h2>
-            <p class="mt-4 text-base leading-7 text-neutral-700">{{ page.extra.article_paths | length }} {% if page.extra.article_paths | length == 1 %}texto{% else %}textos{% endif %}</p>
-          </article>
-        {% endif %}
-      {% endfor %}
+            <p class="story-kicker">
+                {% if page.extra.gender | default(value="m") == "f" %}Autora{%
+                else %}Autor{% endif %}
+            </p>
+            <h2 class="story-title-xs">
+                <a href="{{ page.permalink }}">{{ page.title }}</a>
+            </h2>
+            <p class="mt-4 text-base leading-7 text-neutral-700">
+                {{ page.extra.article_paths | length }} {% if
+                page.extra.article_paths | length == 1 %}texto{% else %}textos{%
+                endif %}
+            </p>
+        </article>
+        {% endif %} {% endfor %}
     </section>
-  </main>
+</main>
 {% endblock content %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,105 +1,198 @@
 {% import "partials/macros.html" as macros %}
-<!DOCTYPE html>
+<!doctype html>
 <html lang="es">
-  <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{% block title %}{{ config.title }}{% endblock title %}</title>
-    <meta name="description" content="{% block meta_description %}{{ config.description }}{% endblock meta_description %}">
-    <script>
-      (() => {
-        const storageKey = "typ:theme";
-        const fallbackTheme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-        try {
-          const saved = localStorage.getItem(storageKey);
-          const theme = saved === "dark" || saved === "light"
-            ? saved
-            : fallbackTheme;
-          document.documentElement.dataset.theme = theme;
-        } catch (_error) {
-          document.documentElement.dataset.theme = fallbackTheme;
-        }
-      })();
-    </script>
-    <link rel="stylesheet" href="/assets/site.css">
-    <script type="module" src="/assets/site.js"></script>
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-    <link rel="alternate" type="application/atom+xml" title="{{ config.title }}" href="{{ get_url(path='atom.xml') }}">
-    <link rel="canonical" href="{% block canonical_url %}{{ config.base_url }}/{% endblock canonical_url %}">
-    <meta property="og:type" content="{% block og_type %}website{% endblock og_type %}">
-    <meta property="og:site_name" content="{{ config.title }}">
-    <meta property="og:locale" content="es_AR">
-    <meta property="og:url" content="{% block og_url %}{{ config.base_url }}/{% endblock og_url %}">
-    <meta property="og:title" content="{% block og_title %}{{ config.title }}{% endblock og_title %}">
-    <meta property="og:description" content="{% block og_description %}{{ config.description }}{% endblock og_description %}">
-    <meta property="og:image" content="{% block og_image %}{{ config.base_url }}/og-image.png{% endblock og_image %}">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="{% block twitter_title %}{{ config.title }}{% endblock twitter_title %}">
-    <meta name="twitter:description" content="{% block twitter_description %}{{ config.description }}{% endblock twitter_description %}">
-    <meta name="twitter:image" content="{% block twitter_image %}{{ config.base_url }}/og-image.png{% endblock twitter_image %}">
-  </head>
-  <body>
-    <div class="page-shell">
-      <div class="utility-bar">
-        <div class="utility-links">
-        </div>
-        <div class="utility-actions">
-          <form class="search-form" action="/buscar/" method="get" role="search">
-            <label class="sr-only" for="site-search">Buscar</label>
-            <input id="site-search" type="search" name="q" placeholder="Buscar…" autocomplete="off">
-            <button type="submit" aria-label="Buscar">⌕</button>
-          </form>
-          <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false" aria-label="Modo oscuro">
-            <span class="theme-toggle-icon" data-theme-icon aria-hidden="true">☾</span>
-          </button>
-        </div>
-      </div>
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>{% block title %}{{ config.title }}{% endblock title %}</title>
+        <meta
+            name="description"
+            content="{% block meta_description %}{{ config.description }}{% endblock meta_description %}"
+        />
+        <script>
+            (() => {
+                const storageKey = "typ:theme";
+                const fallbackTheme = window.matchMedia(
+                    "(prefers-color-scheme: dark)",
+                ).matches
+                    ? "dark"
+                    : "light";
+                try {
+                    const saved = localStorage.getItem(storageKey);
+                    const theme =
+                        saved === "dark" || saved === "light"
+                            ? saved
+                            : fallbackTheme;
+                    document.documentElement.dataset.theme = theme;
+                } catch (_error) {
+                    document.documentElement.dataset.theme = fallbackTheme;
+                }
+            })();
+        </script>
+        <link rel="stylesheet" href="/assets/site.css" />
+        <script type="module" src="/assets/site.js"></script>
+        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+        <link
+            rel="alternate"
+            type="application/atom+xml"
+            title="{{ config.title }}"
+            href="{{ get_url(path='atom.xml') }}"
+        />
+        <link
+            rel="canonical"
+            href="{% block canonical_url %}{{ config.base_url }}/{% endblock canonical_url %}"
+        />
+        <meta
+            property="og:type"
+            content="{% block og_type %}website{% endblock og_type %}"
+        />
+        <meta property="og:site_name" content="{{ config.title }}" />
+        <meta property="og:locale" content="es_AR" />
+        <meta
+            property="og:url"
+            content="{% block og_url %}{{ config.base_url }}/{% endblock og_url %}"
+        />
+        <meta
+            property="og:title"
+            content="{% block og_title %}{{ config.title }}{% endblock og_title %}"
+        />
+        <meta
+            property="og:description"
+            content="{% block og_description %}{{ config.description }}{% endblock og_description %}"
+        />
+        <meta
+            property="og:image"
+            content="{% block og_image %}{{ config.base_url }}/og-image.png{% endblock og_image %}"
+        />
+        <meta
+            property="og:image:width"
+            content="{% block og_image_width %}1200{% endblock og_image_width %}"
+        />
+        <meta
+            property="og:image:height"
+            content="{% block og_image_height %}630{% endblock og_image_height %}"
+        />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta
+            name="twitter:title"
+            content="{% block twitter_title %}{{ config.title }}{% endblock twitter_title %}"
+        />
+        <meta
+            name="twitter:description"
+            content="{% block twitter_description %}{{ config.description }}{% endblock twitter_description %}"
+        />
+        <meta
+            name="twitter:image"
+            content="{% block twitter_image %}{{ config.base_url }}/og-image.png{% endblock twitter_image %}"
+        />
+    </head>
+    <body>
+        <div class="page-shell">
+            <div class="utility-bar">
+                <div class="utility-links"></div>
+                <div class="utility-actions">
+                    <form
+                        class="search-form"
+                        action="/buscar/"
+                        method="get"
+                        role="search"
+                    >
+                        <label class="sr-only" for="site-search">Buscar</label>
+                        <input
+                            id="site-search"
+                            type="search"
+                            name="q"
+                            placeholder="Buscar…"
+                            autocomplete="off"
+                        />
+                        <button type="submit" aria-label="Buscar">⌕</button>
+                    </form>
+                    <button
+                        class="theme-toggle"
+                        type="button"
+                        data-theme-toggle
+                        aria-pressed="false"
+                        aria-label="Modo oscuro"
+                    >
+                        <span
+                            class="theme-toggle-icon"
+                            data-theme-icon
+                            aria-hidden="true"
+                            >☾</span
+                        >
+                    </button>
+                </div>
+            </div>
 
-      <header class="masthead">
-        <div class="masthead-grid">
-          <div>
-            <h1 class="brand-title"><a href="/">{{ config.title }}</a></h1>
-            <p class="story-kicker">de Martín Gaitán</p>
-          </div>
-        </div>
-      </header>
+            <header class="masthead">
+                <div class="masthead-grid">
+                    <div>
+                        <h1 class="brand-title">
+                            <a href="/">{{ config.title }}</a>
+                        </h1>
+                        <p class="story-kicker">de Martín Gaitán</p>
+                    </div>
+                </div>
+            </header>
 
-      <nav class="main-nav">
-        <div class="flex items-center justify-between gap-4 py-4">
-          <div class="main-nav-inner">
-            <a class="nav-link" href="/">Inicio</a>
-            <a class="nav-link" href="/blog/">Blog</a>
-            <a class="nav-link" href="/fotos/">Fotos</a>
-            <a class="nav-link" href="/de-otros/">De otres</a>
-            <a class="nav-link" href="/videos/">Videos</a>
-            <a class="nav-link" href="/random/" rel="nofollow" title="Llevame a un texto al azar">Aleatorio</a>
-            <a class="nav-link hidden lg:inline" href="/autores/">Autoras y autores</a>
-            <a class="nav-link hidden lg:inline" href="/etiquetas/">Etiquetas</a>
-          </div>
-          <button class="nav-toggle" type="button" aria-expanded="false" data-nav-toggle>
-            <span class="sr-only">Abrir navegación</span>
-            <span class="text-xl">+</span>
-          </button>
-        </div>
-        <div class="nav-panel" data-nav-panel data-open="false">
-          <div class="grid gap-3">
-            <a class="nav-link" href="/">Inicio</a>
-            <a class="nav-link" href="/blog/">Blog</a>
-            <a class="nav-link" href="/fotos/">Fotos</a>
-            <a class="nav-link" href="/de-otros/">De otres</a>
-            <a class="nav-link" href="/videos/">Videos</a>
-            <a class="nav-link" href="/random/" rel="nofollow">Aleatorio</a>
-            <a class="nav-link" href="/autores/">Autoras y autores</a>
-            <a class="nav-link" href="/etiquetas/">Etiquetas</a>
-          </div>
-        </div>
-      </nav>
+            <nav class="main-nav">
+                <div class="flex items-center justify-between gap-4 py-4">
+                    <div class="main-nav-inner">
+                        <a class="nav-link" href="/">Inicio</a>
+                        <a class="nav-link" href="/blog/">Blog</a>
+                        <a class="nav-link" href="/fotos/">Fotos</a>
+                        <a class="nav-link" href="/de-otros/">De otres</a>
+                        <a class="nav-link" href="/videos/">Videos</a>
+                        <a
+                            class="nav-link"
+                            href="/random/"
+                            rel="nofollow"
+                            title="Llevame a un texto al azar"
+                            >Aleatorio</a
+                        >
+                        <a class="nav-link hidden lg:inline" href="/autores/"
+                            >Autoras y autores</a
+                        >
+                        <a class="nav-link hidden lg:inline" href="/etiquetas/"
+                            >Etiquetas</a
+                        >
+                    </div>
+                    <button
+                        class="nav-toggle"
+                        type="button"
+                        aria-expanded="false"
+                        data-nav-toggle
+                    >
+                        <span class="sr-only">Abrir navegación</span>
+                        <span class="text-xl">+</span>
+                    </button>
+                </div>
+                <div class="nav-panel" data-nav-panel data-open="false">
+                    <div class="grid gap-3">
+                        <a class="nav-link" href="/">Inicio</a>
+                        <a class="nav-link" href="/blog/">Blog</a>
+                        <a class="nav-link" href="/fotos/">Fotos</a>
+                        <a class="nav-link" href="/de-otros/">De otres</a>
+                        <a class="nav-link" href="/videos/">Videos</a>
+                        <a class="nav-link" href="/random/" rel="nofollow"
+                            >Aleatorio</a
+                        >
+                        <a class="nav-link" href="/autores/"
+                            >Autoras y autores</a
+                        >
+                        <a class="nav-link" href="/etiquetas/">Etiquetas</a>
+                    </div>
+                </div>
+            </nav>
 
-      {% block content %}{% endblock content %}
+            {% block content %}{% endblock content %}
 
-      <footer class="page-footer">
-        <p>{{ config.title }} · {{ config.extra.site_owner }} · {{ config.extra.start_year }}–{{ now() | date(format="%Y") }}</p>
-      </footer>
-    </div>
-  </body>
+            <footer class="page-footer">
+                <p>
+                    {{ config.title }} · {{ config.extra.site_owner }} · {{
+                    config.extra.start_year }}–{{ now() | date(format="%Y") }}
+                </p>
+            </footer>
+        </div>
+    </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,113 +1,121 @@
-{% extends "base.html" %}
-{% import "partials/macros.html" as macros %}
+{% extends "base.html" %} {% import "partials/macros.html" as macros %} {% block
+title %}{{ config.title }}{% endblock title %} {% block meta_description %}Un
+weblog de Martín Gaitán{% endblock meta_description %} {% block canonical_url
+%}{{ config.base_url }}/{% endblock canonical_url %} {% block og_url %}{{
+config.base_url }}/{% endblock og_url %} {% block og_title %}{{ config.title
+}}{% endblock og_title %} {% block og_description %}Un weblog de Martín Gaitán{%
+endblock og_description %} {% block twitter_title %}{{ config.title }}{%
+endblock twitter_title %} {% block twitter_description %}Un weblog de Martín
+Gaitán{% endblock twitter_description %} {% block content %} {% set blog =
+get_section(path="blog/_index.md") %} {% set fotos_section =
+get_section(path="fotos/_index.md") %} {% set featured_photo =
+fotos_section.pages | first %} {% set videos_section =
+get_section(path="videos/_index.md") %} {% set latest_video =
+videos_section.pages | first %} {% set de_otros_section =
+get_section(path="de-otros/_index.md") %} {% set latest_other =
+de_otros_section.pages | first %} {% set blog_pages = blog.pages | slice(end=8)
+%}
 
-{% block title %}{{ config.title }}{% endblock title %}
-{% block meta_description %}Un weblog de Martín Gaitán{% endblock meta_description %}
-{% block og_description %}Un weblog de Martín Gaitán{% endblock og_description %}
-{% block twitter_description %}Un weblog de Martín Gaitán{% endblock twitter_description %}
-
-{% block content %}
-  {% set blog = get_section(path="blog/_index.md") %}
-  {% set fotos_section = get_section(path="fotos/_index.md") %}
-  {% set featured_photo = fotos_section.pages | first %}
-  {% set videos_section = get_section(path="videos/_index.md") %}
-  {% set latest_video = videos_section.pages | first %}
-  {% set de_otros_section = get_section(path="de-otros/_index.md") %}
-  {% set latest_other = de_otros_section.pages | first %}
-  {% set blog_pages = blog.pages | slice(end=8) %}
-
-  <main class="pt-8">
+<main class="pt-8">
     <div class="home-grid">
-      <section class="home-main">
-        <div class="mb-6">
-          <span class="section-ribbon">Últimos del blog</span>
-        </div>
+        <section class="home-main">
+            <div class="mb-6">
+                <span class="section-ribbon">Últimos del blog</span>
+            </div>
 
-        {% if blog_pages | length > 0 %}
-          {% set lead = blog_pages[0] %}
-          <div class="home-lead editorial-rule">
-            {{ macros::story_card(page=lead, variant="feature") }}
-          </div>
+            {% if blog_pages | length > 0 %} {% set lead = blog_pages[0] %}
+            <div class="home-lead editorial-rule">
+                {{ macros::story_card(page=lead, variant="feature") }}
+            </div>
 
-          {% if blog_pages | length > 1 %}
+            {% if blog_pages | length > 1 %}
             <div class="home-blog-rest">
-              {% for page in blog_pages %}
-                {% if not loop.first %}
-                  {{ macros::story_card(page=page, variant="home-list") }}
-                {% endif %}
-              {% endfor %}
+                {% for page in blog_pages %} {% if not loop.first %} {{
+                macros::story_card(page=page, variant="home-list") }} {% endif
+                %} {% endfor %}
             </div>
-          {% endif %}
-        {% endif %}
+            {% endif %} {% endif %}
 
-        <div class="mt-12">
-          <a class="more-link" href="/blog/">Ver más artículos del blog →</a>
-        </div>
-      </section>
-
-      <aside class="home-sidebar">
-        {% if featured_photo %}
-          <div class="sidebar-block">
-            <div class="mb-4">
-              <span class="section-ribbon">Foto</span>
+            <div class="mt-12">
+                <a class="more-link" href="/blog/"
+                    >Ver más artículos del blog →</a
+                >
             </div>
-            {{ macros::story_card(page=featured_photo, variant="compact") }}
-          </div>
-        {% endif %}
+        </section>
 
-        {% if latest_other %}
-          <div class="sidebar-block">
-            <div class="mb-4">
-              <span class="section-ribbon">De otres</span>
-            </div>
-            {{ macros::story_card(page=latest_other, variant="compact") }}
-          </div>
-        {% endif %}
-
-        {% if latest_video %}
-          <div class="sidebar-block">
-            <div class="mb-4">
-              <span class="section-ribbon">Video</span>
-            </div>
-            {{ macros::story_card(page=latest_video, variant="compact") }}
-          </div>
-        {% endif %}
-
-        <div class="sidebar-block">
-          <h2 class="module-title">Más leídos</h2>
-          <div class="index-list" data-popular-reads>
-            {% for path in section.extra.popular_paths | slice(end=5) %}
-              {% set popular = get_page(path=path) %}
-              <article class="index-row">
-                <div class="feed-index">{% if loop.index < 10 %}0{% endif %}{{ loop.index }}</div>
-                <div>
-                  <p class="story-kicker">{{ popular.extra.section_title }}</p>
-                  <h3 class="story-title-xs"><a href="{{ popular.permalink }}">{{ popular.title }}</a></h3>
+        <aside class="home-sidebar">
+            {% if featured_photo %}
+            <div class="sidebar-block">
+                <div class="mb-4">
+                    <span class="section-ribbon">Foto</span>
                 </div>
-              </article>
-            {% endfor %}
-          </div>
-        </div>
+                {{ macros::story_card(page=featured_photo, variant="compact") }}
+            </div>
+            {% endif %} {% if latest_other %}
+            <div class="sidebar-block">
+                <div class="mb-4">
+                    <span class="section-ribbon">De otres</span>
+                </div>
+                {{ macros::story_card(page=latest_other, variant="compact") }}
+            </div>
+            {% endif %} {% if latest_video %}
+            <div class="sidebar-block">
+                <div class="mb-4">
+                    <span class="section-ribbon">Video</span>
+                </div>
+                {{ macros::story_card(page=latest_video, variant="compact") }}
+            </div>
+            {% endif %}
 
-      </aside>
+            <div class="sidebar-block">
+                <h2 class="module-title">Más leídos</h2>
+                <div class="index-list" data-popular-reads>
+                    {% for path in section.extra.popular_paths | slice(end=5) %}
+                    {% set popular = get_page(path=path) %}
+                    <article class="index-row">
+                        <div class="feed-index">
+                            {% if loop.index < 10 %}0{% endif %}{{ loop.index }}
+                        </div>
+                        <div>
+                            <p class="story-kicker">
+                                {{ popular.extra.section_title }}
+                            </p>
+                            <h3 class="story-title-xs">
+                                <a href="{{ popular.permalink }}"
+                                    >{{ popular.title }}</a
+                                >
+                            </h3>
+                        </div>
+                    </article>
+                    {% endfor %}
+                </div>
+            </div>
+        </aside>
     </div>
 
     <section class="home-recent-comments editorial-rule mt-12">
-      <div class="mb-5">
-        <h2 class="module-title mb-0">Comentarios recientes</h2>
-      </div>
-      <div class="home-comments-grid" data-recent-comments>
-        {% for item in section.extra.recent_comments | slice(end=5) %}
-          {% set comment_page = get_page(path=item.article_path) %}
-          <article class="comment-snippet">
-            <p class="story-kicker">{{ item.author | default(value="Anónimo") }} · {{ item.date_display }}</p>
-            <h3 class="story-title-xs">
-              <a href="{{ comment_page.permalink }}#{{ item.anchor }}">{{ comment_page.title }}</a>
-            </h3>
-            <p class="mt-2 text-sm leading-6 text-neutral-700">{{ item.excerpt }}</p>
-          </article>
-        {% endfor %}
-      </div>
+        <div class="mb-5">
+            <h2 class="module-title mb-0">Comentarios recientes</h2>
+        </div>
+        <div class="home-comments-grid" data-recent-comments>
+            {% for item in section.extra.recent_comments | slice(end=5) %} {%
+            set comment_page = get_page(path=item.article_path) %}
+            <article class="comment-snippet">
+                <p class="story-kicker">
+                    {{ item.author | default(value="Anónimo") }} · {{
+                    item.date_display }}
+                </p>
+                <h3 class="story-title-xs">
+                    <a href="{{ comment_page.permalink }}#{{ item.anchor }}"
+                        >{{ comment_page.title }}</a
+                    >
+                </h3>
+                <p class="mt-2 text-sm leading-6 text-neutral-700">
+                    {{ item.excerpt }}
+                </p>
+            </article>
+            {% endfor %}
+        </div>
     </section>
-  </main>
+</main>
 {% endblock content %}

--- a/templates/tag.html
+++ b/templates/tag.html
@@ -1,28 +1,29 @@
-{% extends "base.html" %}
-{% import "partials/macros.html" as macros %}
-
-{% block title %}{{ page.title }} · {{ config.title }}{% endblock title %}
-{% block meta_description %}{{ page.content | striptags | truncate(length=160) }}{% endblock meta_description %}
-{% block canonical_url %}{{ page.permalink }}{% endblock canonical_url %}
-{% block og_url %}{{ page.permalink }}{% endblock og_url %}
-
-{% block content %}
-  <main class="pt-8">
+{% extends "base.html" %} {% import "partials/macros.html" as macros %} {% block
+title %}{{ page.title }} · {{ config.title }}{% endblock title %} {% block
+meta_description %}{{ page.content | striptags | truncate(length=160) }}{%
+endblock meta_description %} {% block canonical_url %}{{ page.permalink }}{%
+endblock canonical_url %} {% block og_url %}{{ page.permalink }}{% endblock
+og_url %} {% block og_title %}{{ page.title }} · {{ config.title }}{% endblock
+og_title %} {% block og_description %}{{ page.content | striptags |
+truncate(length=160) }}{% endblock og_description %} {% block twitter_title %}{{
+page.title }} · {{ config.title }}{% endblock twitter_title %} {% block
+twitter_description %}{{ page.content | striptags | truncate(length=160) }}{%
+endblock twitter_description %} {% block content %}
+<main class="pt-8">
     <section class="editorial-rule">
-      <span class="section-ribbon">Etiqueta</span>
-      <div class="mt-5 max-w-[56rem]">
-        <h2 class="story-title">{{ page.title }}</h2>
-        {% if page.content %}
-          <div class="story-content mt-6">{{ page.content | safe }}</div>
-        {% endif %}
-      </div>
+        <span class="section-ribbon">Etiqueta</span>
+        <div class="mt-5 max-w-[56rem]">
+            <h2 class="story-title">{{ page.title }}</h2>
+            {% if page.content %}
+            <div class="story-content mt-6">{{ page.content | safe }}</div>
+            {% endif %}
+        </div>
     </section>
 
     <section class="listing mt-10">
-      {% for path in page.extra.article_paths %}
-        {% set article = get_page(path=path) %}
-        {{ macros::story_card(page=article, variant="list") }}
-      {% endfor %}
+        {% for path in page.extra.article_paths %} {% set article =
+        get_page(path=path) %} {{ macros::story_card(page=article,
+        variant="list") }} {% endfor %}
     </section>
-  </main>
+</main>
 {% endblock content %}

--- a/templates/tags_index.html
+++ b/templates/tags_index.html
@@ -1,26 +1,31 @@
-{% extends "base.html" %}
-
-{% block title %}Etiquetas · {{ config.title }}{% endblock title %}
-{% block canonical_url %}{{ section.permalink }}{% endblock canonical_url %}
-{% block og_url %}{{ section.permalink }}{% endblock og_url %}
-
-{% block content %}
-  <main class="pt-8">
+{% extends "base.html" %} {% block title %}Etiquetas · {{ config.title }}{%
+endblock title %} {% block canonical_url %}{{ section.permalink }}{% endblock
+canonical_url %} {% block og_url %}{{ section.permalink }}{% endblock og_url %}
+{% block og_title %}Etiquetas · {{ config.title }}{% endblock og_title %} {%
+block og_description %}{{ config.description }}{% endblock og_description %} {%
+block twitter_title %}Etiquetas · {{ config.title }}{% endblock twitter_title %}
+{% block twitter_description %}{{ config.description }}{% endblock
+twitter_description %} {% block content %}
+<main class="pt-8">
     <section class="editorial-rule">
-      <span class="section-ribbon">Etiquetas</span>
-      <div class="mt-5 max-w-[48rem]">
-        <h2 class="story-title">Etiquetas</h2>
-      </div>
+        <span class="section-ribbon">Etiquetas</span>
+        <div class="mt-5 max-w-[48rem]">
+            <h2 class="story-title">Etiquetas</h2>
+        </div>
     </section>
 
     <section class="taxonomy-grid mt-10">
-      {% for page in section.pages | sort(attribute="title") %}
+        {% for page in section.pages | sort(attribute="title") %}
         <article class="taxonomy-card reveal">
-          <p class="story-kicker">{{ page.extra.group_name }}</p>
-          <h2 class="story-title-xs"><a href="{{ page.permalink }}">{{ page.title }}</a></h2>
-          <p class="mt-4 text-base leading-7 text-neutral-700">{{ page.extra.article_paths | length }} textos</p>
+            <p class="story-kicker">{{ page.extra.group_name }}</p>
+            <h2 class="story-title-xs">
+                <a href="{{ page.permalink }}">{{ page.title }}</a>
+            </h2>
+            <p class="mt-4 text-base leading-7 text-neutral-700">
+                {{ page.extra.article_paths | length }} textos
+            </p>
         </article>
-      {% endfor %}
+        {% endfor %}
     </section>
-  </main>
+</main>
 {% endblock content %}


### PR DESCRIPTION
Cierra #232

## Qué se agregó

- `templates/tag.html`: agrega `og:title`, `og:description`, `twitter:title` y `twitter:description` (solo tenía `og:url`)
- `templates/tags_index.html`: ídem, con título "Etiquetas · {site}" y descripción del sitio
- `templates/authors_index.html`: ídem, con título "Autoras y autores · {site}"
- `templates/index.html`: hace explícitos `og:url`, `og:title` y `twitter:title` (los defaults ya eran correctos, pero ahora quedan documentados)
- `templates/base.html`: agrega `og:image:width` (1200) y `og:image:height` (630), que WhatsApp necesita para mostrar la imagen de preview

## Estado previo

`section.html` y `author.html` ya tenían todos los bloques OG correctos. `static/og-image.png` existe.

## Lo que no cambia

Los artículos individuales ya usaban `article.html` que sobreescribe todos los bloques OG correctamente.
