### PR TITLE
Evita links rotos para autores sin página

### DIFF
--- a/data/site_index.json
+++ b/data/site_index.json
@@ -9,7 +9,7 @@
       "is_owner": false,
       "slug": "adriana-battu-pedro-mairal",
       "title": "Adriana Battu (Pedro Mairal)",
-      "url": "/autores/adriana-battu-pedro-mairal/"
+      "url": ""
     },
     "Agarrate Catalina": {
       "articles": [
@@ -20,7 +20,7 @@
       "is_owner": false,
       "slug": "agarrate-catalina",
       "title": "Agarrate Catalina",
-      "url": "/autores/agarrate-catalina/"
+      "url": ""
     },
     "Alejandro Dolina": {
       "articles": [
@@ -58,7 +58,7 @@
       "is_owner": false,
       "slug": "ana-shua",
       "title": "Ana Shua",
-      "url": "/autores/ana-shua/"
+      "url": ""
     },
     "Andrés Kilstein": {
       "articles": [
@@ -69,7 +69,7 @@
       "is_owner": false,
       "slug": "andres-kilstein",
       "title": "Andrés Kilstein",
-      "url": "/autores/andres-kilstein/"
+      "url": ""
     },
     "Antonio Gramsci": {
       "articles": [
@@ -80,7 +80,7 @@
       "is_owner": false,
       "slug": "antonio-gramsci",
       "title": "Antonio Gramsci",
-      "url": "/autores/antonio-gramsci/"
+      "url": ""
     },
     "Baldomero Fernandez Moreno": {
       "articles": [
@@ -103,7 +103,7 @@
       "is_owner": false,
       "slug": "bruno-bimbi",
       "title": "Bruno Bimbi",
-      "url": "/autores/bruno-bimbi/"
+      "url": ""
     },
     "Caetano Veloso": {
       "articles": [
@@ -114,7 +114,7 @@
       "is_owner": false,
       "slug": "caetano-veloso",
       "title": "Caetano Veloso",
-      "url": "/autores/caetano-veloso/"
+      "url": ""
     },
     "Cesar Vallejo": {
       "articles": [
@@ -137,7 +137,7 @@
       "is_owner": false,
       "slug": "charlie-kaufmann",
       "title": "Charlie Kaufmann",
-      "url": "/autores/charlie-kaufmann/"
+      "url": ""
     },
     "Charly García": {
       "articles": [
@@ -172,7 +172,7 @@
       "is_owner": false,
       "slug": "duende-garnica",
       "title": "Duende Garnica",
-      "url": "/autores/duende-garnica/"
+      "url": ""
     },
     "Edmundo Rivero - Iván Diez": {
       "articles": [
@@ -183,7 +183,7 @@
       "is_owner": false,
       "slug": "edmundo-rivero-ivan-diez",
       "title": "Edmundo Rivero - Iván Diez",
-      "url": "/autores/edmundo-rivero-ivan-diez/"
+      "url": ""
     },
     "Eduardo Galeano": {
       "articles": [
@@ -222,7 +222,7 @@
       "is_owner": false,
       "slug": "emanuel-rodriguez",
       "title": "Emanuel Rodriguez",
-      "url": "/autores/emanuel-rodriguez/"
+      "url": ""
     },
     "Emmanuel Carrère": {
       "articles": [
@@ -233,7 +233,7 @@
       "is_owner": false,
       "slug": "emmanuel-carrere",
       "title": "Emmanuel Carrère",
-      "url": "/autores/emmanuel-carrere/"
+      "url": ""
     },
     "Enrique Santos Discépolo": {
       "articles": [
@@ -257,7 +257,7 @@
       "is_owner": false,
       "slug": "ernest-hemingway",
       "title": "Ernest Hemingway",
-      "url": "/autores/ernest-hemingway/"
+      "url": ""
     },
     "Ernesto Sábato": {
       "articles": [
@@ -269,7 +269,7 @@
       "is_owner": false,
       "slug": "ernesto-sabato",
       "title": "Ernesto Sábato",
-      "url": "/autores/ernesto-sabato/"
+      "url": ""
     },
     "Fabián Casas": {
       "articles": [
@@ -292,7 +292,7 @@
       "is_owner": false,
       "slug": "federico-garcia-lorca",
       "title": "Federico García Lorca",
-      "url": "/autores/federico-garcia-lorca/"
+      "url": ""
     },
     "Felix Luna y Ariel Ramirez": {
       "articles": [
@@ -303,7 +303,7 @@
       "is_owner": false,
       "slug": "felix-luna-y-ariel-ramirez",
       "title": "Felix Luna y Ariel Ramirez",
-      "url": "/autores/felix-luna-y-ariel-ramirez/"
+      "url": ""
     },
     "Fernando Cabrera": {
       "articles": [
@@ -326,7 +326,7 @@
       "is_owner": false,
       "slug": "fernando-savater",
       "title": "Fernando Savater",
-      "url": "/autores/fernando-savater/"
+      "url": ""
     },
     "Florencia Lobo": {
       "articles": [
@@ -375,7 +375,7 @@
       "is_owner": false,
       "slug": "gioconda-belli",
       "title": "Gioconda Belli",
-      "url": "/autores/gioconda-belli/"
+      "url": ""
     },
     "Gorka Andraka": {
       "articles": [
@@ -386,7 +386,7 @@
       "is_owner": false,
       "slug": "gorka-andraka",
       "title": "Gorka Andraka",
-      "url": "/autores/gorka-andraka/"
+      "url": ""
     },
     "Graciela Fernández Mayo": {
       "articles": [
@@ -397,7 +397,7 @@
       "is_owner": false,
       "slug": "graciela-fernandez-mayo",
       "title": "Graciela Fernández Mayo",
-      "url": "/autores/graciela-fernandez-mayo/"
+      "url": ""
     },
     "Guillermo Saccomanno": {
       "articles": [
@@ -420,7 +420,7 @@
       "is_owner": false,
       "slug": "hamlet-lima-quintana",
       "title": "Hamlet Lima Quintana",
-      "url": "/autores/hamlet-lima-quintana/"
+      "url": ""
     },
     "Hernán Casciari": {
       "articles": [
@@ -431,7 +431,7 @@
       "is_owner": false,
       "slug": "hernan-casciari",
       "title": "Hernán Casciari",
-      "url": "/autores/hernan-casciari/"
+      "url": ""
     },
     "Homéro Expósito": {
       "articles": [
@@ -442,7 +442,7 @@
       "is_owner": false,
       "slug": "homero-exposito",
       "title": "Homéro Expósito",
-      "url": "/autores/homero-exposito/"
+      "url": ""
     },
     "Isidoro Blaisten": {
       "articles": [
@@ -490,7 +490,7 @@
       "is_owner": false,
       "slug": "joan-manuel-serrat",
       "title": "Joan Manuel Serrat",
-      "url": "/autores/joan-manuel-serrat/"
+      "url": ""
     },
     "Joaquín Sabina": {
       "articles": [
@@ -514,7 +514,7 @@
       "is_owner": false,
       "slug": "jonathan-swift",
       "title": "Jonathan Swift",
-      "url": "/autores/jonathan-swift/"
+      "url": ""
     },
     "Jorge Drexler": {
       "articles": [
@@ -525,7 +525,7 @@
       "is_owner": false,
       "slug": "jorge-drexler",
       "title": "Jorge Drexler",
-      "url": "/autores/jorge-drexler/"
+      "url": ""
     },
     "Jorge Fandermole": {
       "articles": [
@@ -536,7 +536,7 @@
       "is_owner": false,
       "slug": "jorge-fandermole",
       "title": "Jorge Fandermole",
-      "url": "/autores/jorge-fandermole/"
+      "url": ""
     },
     "Jorge Lanata": {
       "articles": [
@@ -608,7 +608,7 @@
       "is_owner": false,
       "slug": "juan-luis-guerra",
       "title": "Juan Luis Guerra",
-      "url": "/autores/juan-luis-guerra/"
+      "url": ""
     },
     "Juan Quintero": {
       "articles": [
@@ -620,7 +620,7 @@
       "is_owner": false,
       "slug": "juan-quintero",
       "title": "Juan Quintero",
-      "url": "/autores/juan-quintero/"
+      "url": ""
     },
     "Juan Rulfo": {
       "articles": [
@@ -643,7 +643,7 @@
       "is_owner": false,
       "slug": "julia-prilutzky-farny",
       "title": "Julia Prilutzky Farny",
-      "url": "/autores/julia-prilutzky-farny/"
+      "url": ""
     },
     "Julio Cortázar": {
       "articles": [
@@ -673,7 +673,7 @@
       "is_owner": false,
       "slug": "la-portuaria",
       "title": "La Portuaria",
-      "url": "/autores/la-portuaria/"
+      "url": ""
     },
     "Lisandro Aristimuño": {
       "articles": [
@@ -685,7 +685,7 @@
       "is_owner": false,
       "slug": "lisandro-aristimuno",
       "title": "Lisandro Aristimuño",
-      "url": "/autores/lisandro-aristimuno/"
+      "url": ""
     },
     "Luis Pescetti": {
       "articles": [
@@ -720,7 +720,7 @@
       "is_owner": false,
       "slug": "manuel-castilla-y-cuchi-leguizamon",
       "title": "Manuel Castilla y Cuchi Leguizamón",
-      "url": "/autores/manuel-castilla-y-cuchi-leguizamon/"
+      "url": ""
     },
     "Manuel del Cabral": {
       "articles": [
@@ -744,7 +744,7 @@
       "is_owner": false,
       "slug": "marco-denevi",
       "title": "Marco Denevi",
-      "url": "/autores/marco-denevi/"
+      "url": ""
     },
     "Marcos Zimmermann": {
       "articles": [
@@ -755,7 +755,7 @@
       "is_owner": false,
       "slug": "marcos-zimmermann",
       "title": "Marcos Zimmermann",
-      "url": "/autores/marcos-zimmermann/"
+      "url": ""
     },
     "Mario Benedetti": {
       "articles": [
@@ -1046,7 +1046,7 @@
       "is_owner": false,
       "slug": "mendieta-abelardo-vitale",
       "title": "Mendieta (Abelardo Vitale)",
-      "url": "/autores/mendieta-abelardo-vitale/"
+      "url": ""
     },
     "Miguel Angel Pérez y Gustavo \"Cuchi\" Leguizamón": {
       "articles": [
@@ -1057,7 +1057,7 @@
       "is_owner": false,
       "slug": "miguel-angel-perez-y-gustavo-cuchi-leguizamon",
       "title": "Miguel Angel Pérez y Gustavo \"Cuchi\" Leguizamón",
-      "url": "/autores/miguel-angel-perez-y-gustavo-cuchi-leguizamon/"
+      "url": ""
     },
     "Nicolás Guillén": {
       "articles": [
@@ -1107,7 +1107,7 @@
       "is_owner": false,
       "slug": "paco-ibanez-y-jose-goytisolo",
       "title": "Paco Ibáñez y José Goytisolo",
-      "url": "/autores/paco-ibanez-y-jose-goytisolo/"
+      "url": ""
     },
     "Pecas Soriano": {
       "articles": [
@@ -1149,7 +1149,7 @@
       "is_owner": false,
       "slug": "preambulo",
       "title": "Preámbulo",
-      "url": "/autores/preambulo/"
+      "url": ""
     },
     "Raúl González Tuñón": {
       "articles": [
@@ -1172,7 +1172,7 @@
       "is_owner": false,
       "slug": "renato-mota",
       "title": "Renato Mota",
-      "url": "/autores/renato-mota/"
+      "url": ""
     },
     "Roberto Fontanarrosa": {
       "articles": [
@@ -1246,7 +1246,7 @@
       "is_owner": false,
       "slug": "sebastian-hacher",
       "title": "Sebastian Hacher",
-      "url": "/autores/sebastian-hacher/"
+      "url": ""
     },
     "Silvio Rodríguez": {
       "articles": [
@@ -31879,8 +31879,8 @@
     "Música": {
       "articles": [
         "videos/mamita-peyote.md",
-        "de-otros/a-traves-de-tus-ojos.md",
         "videos/a-traves-de-tus-ojos.md",
+        "de-otros/a-traves-de-tus-ojos.md",
         "blog/lo-que-quiero.md",
         "de-otros/hermanos.md",
         "de-otros/algo-muy-grave-va-a-suceder-en.md",

--- a/scripts/build_zola_index.py
+++ b/scripts/build_zola_index.py
@@ -145,7 +145,7 @@ def main() -> int:
                     {
                         "title": author,
                         "slug": slugify(author),
-                        "url": f"/autores/{slugify(author)}/",
+                        "url": "",
                         "image": "",
                         "gender": "m",
                         "is_owner": False,
@@ -183,7 +183,7 @@ def main() -> int:
         for item in collection.values():
             item["articles"] = sorted(
                 set(item.get("articles") or []),
-                key=lambda rel: pages.get(rel, {}).get("date", ""),
+                key=lambda rel: (pages.get(rel, {}).get("date", ""), rel),
                 reverse=True,
             )
 


### PR DESCRIPTION
## Qué cambia

- Los autores derivados sólo desde artículos ya no reciben una URL sintética `/autores/.../`.
- Los autores que sí tienen página en `content/autores/` conservan su link.
- El orden de artículos derivados queda estable usando fecha + path como clave.

## Verificación

- `PATH=/tmp/zola-x86:$PATH npm run build`
- `Ernesto Sábato` y `Ana Shua` renderizan como texto plano, sin link roto.
- `Florencia Lobo` conserva el link a `/autores/florencia-lobo/`.

Fixes review comment: https://github.com/mgaitan/textosypretextos/pull/254#discussion_r3214039705
