### PR TITLE
Migrar bloques poetry al shortcode

### DIFF
--- a/content/autores/joaquin-sabina.md
+++ b/content/autores/joaquin-sabina.md
@@ -7,24 +7,26 @@ image = "/media/auton17.jpg"
 is_owner = false
 +++
 
-<div class="poetry">### Mon frère<br>
-<br>
-Vive quinientas noches en un día,<br>
-se disfraza de rayo y de pregunta,<br>
-enciende al elegir con quién se junta<br>
-la sombra de una mala compañía.<br>
-<br>
-No admite su mester de juglaría<br>
-más balazo que el sol cuando despunta.<br>
-Siempre pone un soneto donde apunta<br>
-con el rifle de la melancolía.<br>
-<br>
-Por sus canciones cruzan las ciudades,<br>
-las historias de amor, las soledades,<br>
-los malditos de buenos sentimientos.<br>
-<br>
-Baudelaire con guitarra madrileña,<br>
-Joaquín Sabina escribe lo que sueña<br>
-en la rosa canalla de los vientos.</div>
+{% poetry() %}
+### Mon frère
+
+Vive quinientas noches en un día,
+se disfraza de rayo y de pregunta,
+enciende al elegir con quién se junta
+la sombra de una mala compañía.
+
+No admite su mester de juglaría
+más balazo que el sol cuando despunta.
+Siempre pone un soneto donde apunta
+con el rifle de la melancolía.
+
+Por sus canciones cruzan las ciudades,
+las historias de amor, las soledades,
+los malditos de buenos sentimientos.
+
+Baudelaire con guitarra madrileña,
+Joaquín Sabina escribe lo que sueña
+en la rosa canalla de los vientos.
+{% end %}
 
 *Del Prólogo de "Ciento Volando de Catorce", por Luis García Montero*

--- a/content/blog/ascenso.md
+++ b/content/blog/ascenso.md
@@ -16,15 +16,17 @@ tags = [
 deck = "*A la memoria de Daniel Salzano*"
 +++
 
-<div class="poetry">Adiós poeta / gracias por enseñarme a escarbar el cine / tu cine / sus asientos / tus encondrijos<br>
-<br>
-Adiós poeta / gracias por las barritas / pausitas de adoquín jesuita / donde tus ojos / che culiado / veían como halcón / o mejor como cóndor<br>
-<br>
-Adiós poeta / gracias por la ternura / y el amor a esta ciudad / la tenías entre ceja y ceja / le inventabas sonidos / nubes / jugadores<br>
-<br>
-Adiós poeta / gracias por tu sapiencia / por saber que Chaplín la pisaba como Riquelme / calzaba cuarentinueve<br>
-<br>
-Y gracias por las columnas / tu rutina de obrero / de tinta / hacer columnas que sostienen la luna / y la sostendrán / vos sí ascendiste / poeta</div>
+{% poetry() %}
+Adiós poeta / gracias por enseñarme a escarbar el cine / tu cine / sus asientos / tus encondrijos
+
+Adiós poeta / gracias por las barritas / pausitas de adoquín jesuita / donde tus ojos / che culiado / veían como halcón / o mejor como cóndor
+
+Adiós poeta / gracias por la ternura / y el amor a esta ciudad / la tenías entre ceja y ceja / le inventabas sonidos / nubes / jugadores
+
+Adiós poeta / gracias por tu sapiencia / por saber que Chaplín la pisaba como Riquelme / calzaba cuarentinueve
+
+Y gracias por las columnas / tu rutina de obrero / de tinta / hacer columnas que sostienen la luna / y la sostendrán / vos sí ascendiste / poeta
+{% end %}
 
 {% postscript() %}
 Daniel Salzano (Córdoba, 1941 – 2014) fue periodista, poeta y crítico cultural. Durante décadas escribió en *La Voz del Interior*, donde su columna cinematográfica fue lectura obligada y referencia insoslayable de la cultura cordobesa. Con una prosa poética y profundamente arraigada en la ciudad, convirtió el periodismo cultural en literatura. Amante del fútbol, el cine y la vida cotidiana, su mirada fue siempre la de un poeta que habitaba la ciudad con los ojos abiertos.

--- a/content/blog/collage-de-cinismos.md
+++ b/content/blog/collage-de-cinismos.md
@@ -33,34 +33,35 @@ Mientras el gobernador neuquino coronaba el turno cordobés de su campaña con u
 
 En la pared de una escuela primaria de la ciudad de Córdoba se lee, sobre papel afiche amarillo, una producción grupal de la clase de lengua.   Dice así: 
 
-<div class="poetry">**Mi vida en Córdoba**<br>
-<br>
-*Tus calles he recorrido<br>
-con mi carrito cartoneando.<br>
-No me olvido de esa noche<br>
-cuando me paró la CAP<br>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; en el mercado.<br>
-No tenía documentos<br>
-y me llevaron al centro.*<br>
-<br>
-*Otras noche intoxicado,<br>
-me he bardeado los fines de semana<br>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; y los feriados.<br>
-Cómo olvidarse de esa noche<br>
-que le robé el estereo al coche*<br>
-<br>
-*Qué decir del Parque Las Heras,<br>
-si habré allí arrebatado carteras.<br>
-Y por le Río Suquía<br>
-me habré hecho un par de amigas.*<br>
-<br>
-*Voy cortando cadenas,<br>
-estoy creciendo en miserias;<br>
-pero las personas no mueren,<br>
-porque Córdoba es grande y fuerte.*<br>
-<br>
+{% poetry() %}
+**Mi vida en Córdoba**
+
+*Tus calles he recorrido
+con mi carrito cartoneando.
+No me olvido de esa noche
+cuando me paró la CAP
+                 en el mercado.
+No tenía documentos
+y me llevaron al centro.*
+
+*Otras noche intoxicado,
+me he bardeado los fines de semana
+                 y los feriados.
+Cómo olvidarse de esa noche
+que le robé el estereo al coche*
+
+*Qué decir del Parque Las Heras,
+si habré allí arrebatado carteras.
+Y por le Río Suquía
+me habré hecho un par de amigas.*
+
+*Voy cortando cadenas,
+estoy creciendo en miserias;
+pero las personas no mueren,
+porque Córdoba es grande y fuerte.*
+
 **6ºB - Escuela "Alejandro Carbó"**
-</div>
+{% end %}
 
 En forma perpendicular, pegado en el vidrio de la puerta de entrada al establecimiento, hay otro cartel. Está hecho en una impresora de matriz de puntos con poca tinta y prolijamente plastificado en cintéx. Advierte:  
 

--- a/content/blog/con-tanta-noche-por-la-ventana.md
+++ b/content/blog/con-tanta-noche-por-la-ventana.md
@@ -30,12 +30,14 @@ De este si sé algo, Abel Cháneton. Fue historiador, periodista,
 intendente de Neuquén y, lo que más me simpatiza, amigo de Discepolín. Lo
 menciona en "Cafetín de Buenos Aires":
 
-<div class="poetry">Me diste en oro un puñado de amigos<br>
-que son los mismos que alientan mis horas:<br>
-José, el de la quimera<br>
-Marcial que aún cree y espera<br>
-y el flaco Abel que se nos fue<br>
-pero aún me guía.</div>
+{% poetry() %}
+Me diste en oro un puñado de amigos
+que son los mismos que alientan mis horas:
+José, el de la quimera
+Marcial que aún cree y espera
+y el flaco Abel que se nos fue
+pero aún me guía.
+{% end %}
 
 En esa pista, la del Don Bosco, corrí los 100 metros más rápidos de mi
 vida. Tenía 9 años y dos piernas fuertes para mi cuerpo pequeño.

--- a/content/blog/contener-la-respiracion.md
+++ b/content/blog/contener-la-respiracion.md
@@ -35,35 +35,37 @@ _ *Falta y Resto*
 
 {{ video_embed(provider="youtube", id="bQFFtNhEKsw") }}
 
-<div class="poetry">Florecen en el viento fresco de primavera<br>
-Anidan en los montes a orillas del amor<br>
-Son gotas de rocío que empapan la esperanza<br>
-Son luz de un arcoíris de infinito color<br>
-<br>
-Viven en la memoria de todas las esquinas<br>
-Rugen entre las olas tormentosas del sur<br>
-Gritan desde el recuerdo su alarido de triunfo<br>
-Aparecen cantando su eterna juventud<br>
-<br>
-Recitan la poesía de los amaneceres<br>
-Tibio y claro silencio de una voz que no está<br>
-Aparecen corriendo para hacernos la pica<br>
-Y liberar al último que falte liberar.<br>
-<br>
-Juegan todos los juegos que jugaron de niños<br>
-Bailan todas las danzas que les toque bailar<br>
-Son carne, piel y huesos de esa patria marchita<br>
-Que de su sacrificio habrá de germinar<br>
-<br>
-Son la voz de la noche, la piel de la mañana<br>
-Aroma de la feria, un sol en el pretil<br>
-Unas adolescentes sonriendo enamoradas<br>
-El retumbo en los barrios que agitan tamboril<br>
-<br>
-Aparecerán siempre que querramos buscarlos<br>
-Cual calcio en las entrañas de un país fraternal<br>
-Sangre sobre los surcos cultivando conciencias<br>
-Cosechando alegría, siempre aparecerán.</div>
+{% poetry() %}
+Florecen en el viento fresco de primavera
+Anidan en los montes a orillas del amor
+Son gotas de rocío que empapan la esperanza
+Son luz de un arcoíris de infinito color
+
+Viven en la memoria de todas las esquinas
+Rugen entre las olas tormentosas del sur
+Gritan desde el recuerdo su alarido de triunfo
+Aparecen cantando su eterna juventud
+
+Recitan la poesía de los amaneceres
+Tibio y claro silencio de una voz que no está
+Aparecen corriendo para hacernos la pica
+Y liberar al último que falte liberar.
+
+Juegan todos los juegos que jugaron de niños
+Bailan todas las danzas que les toque bailar
+Son carne, piel y huesos de esa patria marchita
+Que de su sacrificio habrá de germinar
+
+Son la voz de la noche, la piel de la mañana
+Aroma de la feria, un sol en el pretil
+Unas adolescentes sonriendo enamoradas
+El retumbo en los barrios que agitan tamboril
+
+Aparecerán siempre que querramos buscarlos
+Cual calcio en las entrañas de un país fraternal
+Sangre sobre los surcos cultivando conciencias
+Cosechando alegría, siempre aparecerán.
+{% end %}
 
 {% postscript() %}
 Ya subí [las fotos de la jornada](@/fotos/ii-jornadas-populares-y.md).

--- a/content/blog/dulce-y-tenaz.md
+++ b/content/blog/dulce-y-tenaz.md
@@ -35,38 +35,40 @@ Se lo admira, se lo respeta y se lo quiere. Por todo lo que hizo, y lo que sigue
 
 El domingo a las 3 de la tarde mis compañeros debían irse al [taller de serigrafía](http://www.agrupacionmazamorra.com.ar) que estamos haciendo con los chicos del barrio. Los compañeros del Movimiento Teresa Rodriguez nos hicieron un encargo, con la idea de que se convirtiera en la primera producción del taller: pañuelos con la cara del Che. Como corresponde a nuestra concepción de educación popular, antes que nada debíamos trabajar en torno a la figura del Che y me acordé del bello poema: 
 
-<div class="poetry">**Che 1997**<br>
-<br>
-Lo han cubierto/ de afiches de pancartas<br>
-de voces en los muros<br>
-de agravios retroactivos<br>
-de honores a destiempo<br>
-<br>
-lo han transformado en pieza de consumo<br>
-en memoria trivial<br>
-en ayer sin retorno<br>
-en rabia embalsamada<br>
-<br>
-han decidido usarlo como epílogo<br>
-como última thule de la inocencia vana<br>
-como añejo arquetipo de santo o satanás<br>
-<br>
-y quizás han resuelto que la única forma<br>
-de desprenderse de él<br>
-o dejarlo al garete<br>
-es vaciarlo de lumbre<br>
-convertirlo en un héroe<br>
-de mármol o de yeso<br>
-y por lo tanto inmóvil<br>
-o mejor como mito<br>
-o silueta o fantasma<br>
-del pasado pisado<br>
-<br>
-sin embargo los ojos incerrables del che<br>
-miran como si no pudieran no mirar<br>
-asombrados tal vez de que el mundo<br>
-no entienda que treinta años después<br>
-sigue bregando dulce y tenaz por la dicha del hombre.</div>
+{% poetry() %}
+**Che 1997**
+
+Lo han cubierto/ de afiches de pancartas
+de voces en los muros
+de agravios retroactivos
+de honores a destiempo
+
+lo han transformado en pieza de consumo
+en memoria trivial
+en ayer sin retorno
+en rabia embalsamada
+
+han decidido usarlo como epílogo
+como última thule de la inocencia vana
+como añejo arquetipo de santo o satanás
+
+y quizás han resuelto que la única forma
+de desprenderse de él
+o dejarlo al garete
+es vaciarlo de lumbre
+convertirlo en un héroe
+de mármol o de yeso
+y por lo tanto inmóvil
+o mejor como mito
+o silueta o fantasma
+del pasado pisado
+
+sin embargo los ojos incerrables del che
+miran como si no pudieran no mirar
+asombrados tal vez de que el mundo
+no entienda que treinta años después
+sigue bregando dulce y tenaz por la dicha del hombre.
+{% end %}
 
 <p>
 A las seis de la tarde, mientras una voz militante leía su poema en un barrio pobre de Córdoba, su cuerpo moría en una habitación de Montevideo. En ese instante, no lo detuvo la distancia ni la despedida. Como ayer, como siempre, sigue bregando, dulce y tenaz, por la dicha del hombre.</p>

--- a/content/blog/limando-cantos-i.md
+++ b/content/blog/limando-cantos-i.md
@@ -21,9 +21,11 @@ Lo que sigue es el email de difusión y la discusión que entablé en el [grupo 
 
 ### --------
 
-<div class="poetry">From: Juan <copybin@gm...><br>
-To: ing_computacion@googleg...<br>
-Date: 10 de marzo de 2008 11:44</div>
+{% poetry() %}
+From: Juan <copybin@gm...>
+To: ing_computacion@googleg...
+Date: 10 de marzo de 2008 11:44
+{% end %}
 
 ### --------
 
@@ -56,10 +58,12 @@ Sec. de Graduados y RR. Institucionales FCEFyN UNC
 
 ### --------
 
-<div class="poetry">From: Emilio Gallego <gaitan@gm...><br>
-To: ing_computacion@googleg...<br>
-Cc: graduados@efn.uncor.edu<br>
-Date: 10 de marzo de 2008 18:12</div>
+{% poetry() %}
+From: Emilio Gallego <gaitan@gm...>
+To: ing_computacion@googleg...
+Cc: graduados@efn.uncor.edu
+Date: 10 de marzo de 2008 18:12
+{% end %}
 
 ### --------
 
@@ -102,9 +106,11 @@ Emilio
 
 ### --------
 
-<div class="poetry">From: Pablo Parra <pablo.passera@gma...><br>
-To: ing_computacion@googlegr...<br>
-Date: 10 de marzo de 2008 18:37</div>
+{% poetry() %}
+From: Pablo Parra <pablo.passera@gma...>
+To: ing_computacion@googlegr...
+Date: 10 de marzo de 2008 18:37
+{% end %}
 
 ### --------
 
@@ -115,9 +121,11 @@ Pablo
 
 ### --------
 
-<div class="poetry">From: Emilio Gallego <gaitan@gm...><br>
-To: ing_computacion@googlegr...<br>
-Date: 10 de marzo de 2008 20:11</div>
+{% poetry() %}
+From: Emilio Gallego <gaitan@gm...>
+To: ing_computacion@googlegr...
+Date: 10 de marzo de 2008 20:11
+{% end %}
 
 ### --------
 
@@ -184,9 +192,11 @@ Emilio
 
 ### --------
 
-<div class="poetry">From: Pablo Parra <pablo.passera@gm...><br>
-To: ing_computacion@googleg...<br>
-Date: 10 de marzo de 2008 20:31</div>
+{% poetry() %}
+From: Pablo Parra <pablo.passera@gm...>
+To: ing_computacion@googleg...
+Date: 10 de marzo de 2008 20:31
+{% end %}
 
 ### --------
 Buenas Martin, un par de comentarios...
@@ -200,9 +210,11 @@ Pablo
 
 ### --------
 
-<div class="poetry">From: Emilio Gallego <gaitan@gmail.com><br>
-To: ing_computacion@googlegr...<br>
-Date: 10 de marzo de 2008 22:13</div>
+{% poetry() %}
+From: Emilio Gallego <gaitan@gmail.com>
+To: ing_computacion@googlegr...
+Date: 10 de marzo de 2008 22:13
+{% end %}
 
 ### --------
 El 10/03/08, Pablo Parra <pablo.passera@gm...> escribió:

--- a/content/blog/limando-cantos-ii.md
+++ b/content/blog/limando-cantos-ii.md
@@ -829,11 +829,13 @@ hay paredes?
  Y no odio a nadie, simplemente intento construir. Hay una [hermosa canción](http://www.youtube.com/watch?v=aUesKxY7CPI) de
  Fito Páez que canta Baglietto:
 
-<div class="poetry">"Todavía me emocionan ciertas voces<br>
- todavía creo en mirar a los ojos<br>
- todavía tengo en mente cambiar algo<br>
- [...]<br>
- multiplicar, es la tarea, es la tarea ..."</div>
+{% poetry() %}
+"Todavía me emocionan ciertas voces
+ todavía creo en mirar a los ojos
+ todavía tengo en mente cambiar algo
+ [...]
+ multiplicar, es la tarea, es la tarea ..."
+{% end %}
 
  Multiplicar es la tarea. Y en eso estamos varios.
 

--- a/content/blog/pasar.md
+++ b/content/blog/pasar.md
@@ -50,34 +50,36 @@ A la tarde, lleno de felicidad, Gabi mandó un mail:
 
 El cariño, más allá de todo. Leí, releí, y entonces, sin vergüenza, mis lágrimas rodaron cara abajo y mis mocos salieron a saludar. Cuando se me pasó la petrificación (la emoción está intacta), escribí esto y lo mandé con forma de abrazo: 
 
-<div class="poetry">### El niño<br>
-<br>
-Mundo ingrato este<br>
-que le exige al niño lo que no le da.<br>
-Esfuerzo, respuestas, perseverancia<br>
-condiciones y la tabla del dos<br>
-<br>
-No contempla contextos<br>
-no concibe falencias<br>
-no vacila en la hoguera<br>
-<br>
-El niño tiene algunos años<br>
-y más problemas:<br>
-ni su familia, ni su maestra<br>
-tampoco él mismo (lo aprendió de chiquito)<br>
-creen que pueda<br>
-<br>
-Pero hay algunos más brutos<br>
-que nunca aprendieron la lección de memoria.<br>
-Ni de chiquitos ni de grandes supieron repetir<br>
-que el niño no puede<br>
-<br>
-Convencidos, contrariados,<br>
-contra el viento y la lluvia<br>
-le dieron un abrazo al niño<br>
-uno de otro planeta.<br>
-<br>
-El niño pasó de grado.<br>
-Y pasó de mundo.<br>
-<br>
-*Emocionado hasta los tuétanos, mis más afectuoso abrazo a los compañeros y compañeras que hicieron este logro realidad. Y a Damián, ese pequeño gran luchador.*</div>
+{% poetry() %}
+### El niño
+
+Mundo ingrato este
+que le exige al niño lo que no le da.
+Esfuerzo, respuestas, perseverancia
+condiciones y la tabla del dos
+
+No contempla contextos
+no concibe falencias
+no vacila en la hoguera
+
+El niño tiene algunos años
+y más problemas:
+ni su familia, ni su maestra
+tampoco él mismo (lo aprendió de chiquito)
+creen que pueda
+
+Pero hay algunos más brutos
+que nunca aprendieron la lección de memoria.
+Ni de chiquitos ni de grandes supieron repetir
+que el niño no puede
+
+Convencidos, contrariados,
+contra el viento y la lluvia
+le dieron un abrazo al niño
+uno de otro planeta.
+
+El niño pasó de grado.
+Y pasó de mundo.
+
+*Emocionado hasta los tuétanos, mis más afectuoso abrazo a los compañeros y compañeras que hicieron este logro realidad. Y a Damián, ese pequeño gran luchador.*
+{% end %}

--- a/content/blog/poemario-de-una-breve-eternidad.md
+++ b/content/blog/poemario-de-una-breve-eternidad.md
@@ -12,108 +12,110 @@ tags = [
 ]
 +++
 
-<div class="poetry">Busco tu voz, tu hola, tu estás ahí,<br>
-una seña, un estoy bien<br>
-un seremos fuertes,<br>
-    siéndolo.<br>
-Quiero que llegue, minutos días siglos<br>
-el momento de extenderte mis brazos<br>
-mis almitas en ellos<br>
-y que dejes caer tu piel<br>
-en mi palabra<br>
-<br>
-<br>
-Quien dijo oh, otra vez lunes,<br>
-Quien pudo creer alguna vez<br>
-que un fin de semana<br>
-de los de esta especie<br>
-sabe volar.<br>
-<br>
-<br>
-Huelo ausencias<br>
-   como flores de exilio<br>
-dijo un poeta que ayer conocí<br>
-Garabateado con letra de médico,<br>
-este poeta que sabe curar<br>
-me regaló su libro<br>
-cuando le conté que escribía<br>
-programas y pretextos<br>
-para infligirme felicidad<br>
-<br>
-<br>
-Te he pensado, y he pensádote<br>
-en un sentido y en otro<br>
-y después al revés<br>
-y de nuevo al izquierdo<br>
-pasando por arriba<br>
-y bajo detalle,<br>
-cada segundo de este milenio<br>
-   de algunos días.<br>
-Llegué a la conclusión<br>
-de que me gusta el camino<br>
-que deberemos descubrir<br>
-<br>
-<br>
-La flores me saludaron hoy,<br>
-menos tímidas que el sol<br>
-mientras les daba de beber<br>
-Les confesé que me recordaban<br>
-al lila de tus labios<br>
-besando con la memoria<br>
-   y el futuro<br>
-<br>
-<br>
-He de escribirte universos,<br>
-palabras y cuerpos,<br>
-hasta que el sol caliente de nuevo.<br>
-o sea,<br>
-cuando alguno de estos aparatos<br>
-mencione tu nombre<br>
-en letra imprenta<br>
-Entonces, algo,<br>
-diga lo diga,<br>
-nadie sabe qué,<br>
-dejará de nacer<br>
-para hacerse de este mundo<br>
-<br>
-<br>
-Este aleteo de teclas<br>
-para combatir<br>
-el miedo,<br>
-  el frío<br>
-     la inefable incertidumbre<br>
- y sentirte más cerca<br>
-sólo le hace tachones al silencio<br>
-Pero se lee claramente<br>
-que grita por vos<br>
-con la alegría de existirnos<br>
-<br>
-<br>
-Caminar por las paredes<br>
-es el eufemismo popular<br>
-para decir que uno<br>
-vuela por el piso<br>
-rastreando los bichitos<br>
-que titilan intensamente.<br>
-El amor, como esas lucecitas,<br>
-no se apaga tan pronto<br>
-Se tapa con las alas de volar<br>
-cuando hace frío.<br>
-<br>
-<br>
-Si yo digo que te amo,<br>
-qué pensás que digo?<br>
-qué sentís que pienso ?<br>
-qué escuchas que siento?<br>
-Por todo eso, mujer.<br>
-Por escucharme,<br>
-por sentirme<br>
-por pensarme<br>
-por amarme tanto<br>
-Por embellercerte a mi lado<br>
-y hacerme más bello<br>
-como dijo Juan el poeta<br>
-es que quiero con vos<br>
-como el primer día, compañera<br>
-  o más<br>
-mi lugar en la tierra</div>
+{% poetry() %}
+Busco tu voz, tu hola, tu estás ahí,
+una seña, un estoy bien
+un seremos fuertes,
+    siéndolo.
+Quiero que llegue, minutos días siglos
+el momento de extenderte mis brazos
+mis almitas en ellos
+y que dejes caer tu piel
+en mi palabra
+
+
+Quien dijo oh, otra vez lunes,
+Quien pudo creer alguna vez
+que un fin de semana
+de los de esta especie
+sabe volar.
+
+
+Huelo ausencias
+   como flores de exilio
+dijo un poeta que ayer conocí
+Garabateado con letra de médico,
+este poeta que sabe curar
+me regaló su libro
+cuando le conté que escribía
+programas y pretextos
+para infligirme felicidad
+
+
+Te he pensado, y he pensádote
+en un sentido y en otro
+y después al revés
+y de nuevo al izquierdo
+pasando por arriba
+y bajo detalle,
+cada segundo de este milenio
+   de algunos días.
+Llegué a la conclusión
+de que me gusta el camino
+que deberemos descubrir
+
+
+La flores me saludaron hoy,
+menos tímidas que el sol
+mientras les daba de beber
+Les confesé que me recordaban
+al lila de tus labios
+besando con la memoria
+   y el futuro
+
+
+He de escribirte universos,
+palabras y cuerpos,
+hasta que el sol caliente de nuevo.
+o sea,
+cuando alguno de estos aparatos
+mencione tu nombre
+en letra imprenta
+Entonces, algo,
+diga lo diga,
+nadie sabe qué,
+dejará de nacer
+para hacerse de este mundo
+
+
+Este aleteo de teclas
+para combatir
+el miedo,
+  el frío
+     la inefable incertidumbre
+ y sentirte más cerca
+sólo le hace tachones al silencio
+Pero se lee claramente
+que grita por vos
+con la alegría de existirnos
+
+
+Caminar por las paredes
+es el eufemismo popular
+para decir que uno
+vuela por el piso
+rastreando los bichitos
+que titilan intensamente.
+El amor, como esas lucecitas,
+no se apaga tan pronto
+Se tapa con las alas de volar
+cuando hace frío.
+
+
+Si yo digo que te amo,
+qué pensás que digo?
+qué sentís que pienso ?
+qué escuchas que siento?
+Por todo eso, mujer.
+Por escucharme,
+por sentirme
+por pensarme
+por amarme tanto
+Por embellercerte a mi lado
+y hacerme más bello
+como dijo Juan el poeta
+es que quiero con vos
+como el primer día, compañera
+  o más
+mi lugar en la tierra
+{% end %}

--- a/content/blog/puedo.md
+++ b/content/blog/puedo.md
@@ -12,24 +12,26 @@ tags = [
 ]
 +++
 
-<div class="poetry">puedo jubilar la remera manchada<br>
-no extraditar de la cocina el repasador<br>
-acudir a la mesa a la voz de está listo<br>
-y estirar la sábana sobre el colchón<br>
-<br>
-puedo combatir la ingravidez de mi pelo<br>
-dejar el baño como un sahara<br>
-regar y no regar según corresponda<br>
-y hacer la abdominal día por medio<br>
-<br>
-puedo aprender a lavar mi cara<br>
-a escuchar más música y menos noticias<br>
-y terminar los libros que te empiezo a leer<br>
-<br>
-puedo dormir en horario occidental<br>
-hacer el amor hasta que el amor nos haga<br>
-comer la ensalada también cuando no estás<br>
-y no olvidarme de los días siete<br>
-<br>
-pero sé que no son estas las razones<br>
-porque no querés enamorarte de otro</div>
+{% poetry() %}
+puedo jubilar la remera manchada
+no extraditar de la cocina el repasador
+acudir a la mesa a la voz de está listo
+y estirar la sábana sobre el colchón
+
+puedo combatir la ingravidez de mi pelo
+dejar el baño como un sahara
+regar y no regar según corresponda
+y hacer la abdominal día por medio
+
+puedo aprender a lavar mi cara
+a escuchar más música y menos noticias
+y terminar los libros que te empiezo a leer
+
+puedo dormir en horario occidental
+hacer el amor hasta que el amor nos haga
+comer la ensalada también cuando no estás
+y no olvidarme de los días siete
+
+pero sé que no son estas las razones
+porque no querés enamorarte de otro
+{% end %}

--- a/content/blog/tres-grageas-para-mama.md
+++ b/content/blog/tres-grageas-para-mama.md
@@ -31,37 +31,39 @@ Mi vieja me servía la leche soplando el jarro con fuerza para que no cayera la 
 
 Dany puso un disco que le grabaron. Quería que escuchara una versión de *"Down on the corner"* de Creedence, versionada en un inglés sobrepronunciado que la hace simpáticamente pegadiza. Yo miraba un partido de España y no prestaba demasiada atención a nada, pero llegó esta canción y me sorpendió. Es un regalo para vos, mamá. Después de todo, parafraseando a  Mario en *"El cartero de Neruda"*, la poesía no es de quien la escribe sino de quien la necesita.
 
-<div class="poetry">**A través de tus ojos - La Portuaria**<br>
-<br>
-Yo puedo ver el mundo<br>
-y comprender el paso de los días.<br>
-Y entendemos sin palabras,<br>
-abrazando nuestro cómplice silencio<br>
-<br>
-Tu risa vuelve el tiempo mas liviano y vulnerable<br>
-y pierden peso las cosas del mundo.<br>
-Son mejores a través de tu mirada.<br>
-<br>
-Donde corre el agua,<br>
-donde sopla el viento,<br>
-puedo ver a través de tus ojos.<br>
-<br>
-Ya nada se detiene,<br>
-las cosas son distintas,<br>
-Y atravesando el muro de viejas armaduras<br>
-las fórmulas no tienen más sentido.<br>
-<br>
-Tus ojos me despiertan si me quedo dormido.<br>
-yo sueño tu futuro y lo vivo cada día,<br>
-y en cada cosa que hago<br>
-vos siempre estás conmigo.<br>
-<br>
-Donde corre el agua,<br>
-donde sopla el viento,<br>
-puedo ver a través de tus ojos.<br>
-Donde corre el agua,<br>
-donde duerme el tiempo,<br>
-puedo ver a través de tus ojos.</div>
+{% poetry() %}
+**A través de tus ojos - La Portuaria**
+
+Yo puedo ver el mundo
+y comprender el paso de los días.
+Y entendemos sin palabras,
+abrazando nuestro cómplice silencio
+
+Tu risa vuelve el tiempo mas liviano y vulnerable
+y pierden peso las cosas del mundo.
+Son mejores a través de tu mirada.
+
+Donde corre el agua,
+donde sopla el viento,
+puedo ver a través de tus ojos.
+
+Ya nada se detiene,
+las cosas son distintas,
+Y atravesando el muro de viejas armaduras
+las fórmulas no tienen más sentido.
+
+Tus ojos me despiertan si me quedo dormido.
+yo sueño tu futuro y lo vivo cada día,
+y en cada cosa que hago
+vos siempre estás conmigo.
+
+Donde corre el agua,
+donde sopla el viento,
+puedo ver a través de tus ojos.
+Donde corre el agua,
+donde duerme el tiempo,
+puedo ver a través de tus ojos.
+{% end %}
 
 {{ video_embed(provider="youtube", id="8Xl5ZaInIc8") }}
 

--- a/content/de-otros/a-la-orilla-de-la-chimenea.md
+++ b/content/de-otros/a-la-orilla-de-la-chimenea.md
@@ -11,52 +11,54 @@ tags = [
 ]
 +++
 
-<div class="poetry">Puedo ponerme cursi y decir<br>
-que tus labios me saben igual que los labios<br>
-que beso en mis sueños,<br>
-puedo ponerme triste y decir<br>
-que me basta con ser tu enemigo, tu todo,<br>
-tu esclavo, tu fiebre, tu dueño.<br>
-<br>
-Y si quieres también<br>
-puedo ser tu estación y tu tren,<br>
-tu mal y tu bien,<br>
-tu pan y tu vino,<br>
-tu pecado, tu dios, tu asesino…<br>
-<br>
-O tal vez esa sombra<br>
-que se tumba a tu lado en la alfombra<br>
-a la orilla de la chimenea<br>
-a esperar que suba la marea.<br>
-<br>
-Puedo ponerme humilde y decir<br>
-que no soy el mejor<br>
-que me falta valor para atarte a mi cama,<br>
-puedo ponerme digno y decir<br>
-"toma mi dirección cuando te hartes de amores<br>
-baratos de un rato… me llamas".<br>
-<br>
-Y si quieres también<br>
-puedo ser tu trapecio y tu red,<br>
-tu adiós y tu "ven",<br>
-tu manta y tu frío,<br>
-tu resaca, tu lunes, tu hastio…<br>
-<br>
-O tal vez ese viento<br>
-que te arranca del aburrimiento<br>
-y te deja abrazada a una duda,<br>
-en mitad de la calle y desnuda.<br>
-<br>
-Y si quieres también<br>
-puedo ser tu abogado y tu juez,<br>
-tu miedo y tu fe<br>
-tu noche y tu día.<br>
-<br>
-Tu rencor, tu por que, tu agonía…<br>
-o tal vez esa sombra<br>
-que se tumba a tu lado en la alfombra<br>
-a la orilla de la chimenea<br>
-a esperar que suba la marea.</div>
+{% poetry() %}
+Puedo ponerme cursi y decir
+que tus labios me saben igual que los labios
+que beso en mis sueños,
+puedo ponerme triste y decir
+que me basta con ser tu enemigo, tu todo,
+tu esclavo, tu fiebre, tu dueño.
+
+Y si quieres también
+puedo ser tu estación y tu tren,
+tu mal y tu bien,
+tu pan y tu vino,
+tu pecado, tu dios, tu asesino…
+
+O tal vez esa sombra
+que se tumba a tu lado en la alfombra
+a la orilla de la chimenea
+a esperar que suba la marea.
+
+Puedo ponerme humilde y decir
+que no soy el mejor
+que me falta valor para atarte a mi cama,
+puedo ponerme digno y decir
+"toma mi dirección cuando te hartes de amores
+baratos de un rato… me llamas".
+
+Y si quieres también
+puedo ser tu trapecio y tu red,
+tu adiós y tu "ven",
+tu manta y tu frío,
+tu resaca, tu lunes, tu hastio…
+
+O tal vez ese viento
+que te arranca del aburrimiento
+y te deja abrazada a una duda,
+en mitad de la calle y desnuda.
+
+Y si quieres también
+puedo ser tu abogado y tu juez,
+tu miedo y tu fe
+tu noche y tu día.
+
+Tu rencor, tu por que, tu agonía…
+o tal vez esa sombra
+que se tumba a tu lado en la alfombra
+a la orilla de la chimenea
+a esperar que suba la marea.
+{% end %}
 
 {% postscript() %}
 Interpretado por Joan Manuel Serrat, en la gira *Dos pájaros de un tiro*

--- a/content/de-otros/a-traves-de-tus-ojos.md
+++ b/content/de-otros/a-traves-de-tus-ojos.md
@@ -15,34 +15,36 @@ tags = [
 
 {{ video_embed(provider="youtube", id="8Xl5ZaInIc8", title="A través de tus ojos - La Portuaria") }}
 
-<div class="poetry">Yo puedo ver el mundo<br>
-y comprender el paso de los días.<br>
-Entendernos sin palabras,<br>
-abrazando nuestro cómplice silencio.<br>
-<br>
-Tu risa vuelve el tiempo más liviano y vulnerable,<br>
-y pierden peso las cosas del mundo.<br>
-Son mejores a través de tu mirada.<br>
-<br>
-Donde corre el agua,<br>
-donde sopla el viento,<br>
-puedo ver a través de tus ojos.<br>
-<br>
-Ya nada se detiene,<br>
-las cosas son distintas.<br>
-Atravesando el muro de viejas armaduras<br>
-las fórmulas no tienen más sentido.<br>
-<br>
-Tus ojos me despiertan si me quedo dormido.<br>
-Yo sueño tu futuro y lo vivo cada día,<br>
-y en cada cosa que hago vos siempre estás conmigo.<br>
-<br>
-Donde corre el agua,<br>
-donde sopla el viento,<br>
-puedo ver a través de tus ojos.<br>
-Donde corre el agua,<br>
-donde duerme el tiempo,<br>
-puedo ver a través de tus ojos.</div>
+{% poetry() %}
+Yo puedo ver el mundo
+y comprender el paso de los días.
+Entendernos sin palabras,
+abrazando nuestro cómplice silencio.
+
+Tu risa vuelve el tiempo más liviano y vulnerable,
+y pierden peso las cosas del mundo.
+Son mejores a través de tu mirada.
+
+Donde corre el agua,
+donde sopla el viento,
+puedo ver a través de tus ojos.
+
+Ya nada se detiene,
+las cosas son distintas.
+Atravesando el muro de viejas armaduras
+las fórmulas no tienen más sentido.
+
+Tus ojos me despiertan si me quedo dormido.
+Yo sueño tu futuro y lo vivo cada día,
+y en cada cosa que hago vos siempre estás conmigo.
+
+Donde corre el agua,
+donde sopla el viento,
+puedo ver a través de tus ojos.
+Donde corre el agua,
+donde duerme el tiempo,
+puedo ver a través de tus ojos.
+{% end %}
 
 {% postscript() %}
 Autores: Frenkel / Schachtel / Belmonte.

--- a/content/de-otros/aire-durando.md
+++ b/content/de-otros/aire-durando.md
@@ -9,23 +9,25 @@ authors = [
 tags = []
 +++
 
-<div class="poetry">¿Quién ha matado este hombre<br>
-que su voz no está enterrada?<br>
-<br>
-Hay muertos que van subiendo<br>
-cuanto más su ataúd baja...<br>
-Este sudor... ¿por quién muere?<br>
-¿por qué cosa muere un pobre?<br>
-¿Quién ha matado estas manos?<br>
-¡No cabe en la muerte un hombre!<br>
-Hay muertos que van subiendo<br>
-cuanto más su ataúd baja...<br>
-¿Quién acostó su estatura<br>
-que su voz está parada?<br>
-<br>
-Hay muertos como raíces<br>
-que hundidas... dan fruto al ala.<br>
-¿Quién ha matado estas manos,<br>
-este sudor, esta cara?<br>
-Hay muertos que van subiendo<br>
-cuanto más su ataúd baja...</div>
+{% poetry() %}
+¿Quién ha matado este hombre
+que su voz no está enterrada?
+
+Hay muertos que van subiendo
+cuanto más su ataúd baja...
+Este sudor... ¿por quién muere?
+¿por qué cosa muere un pobre?
+¿Quién ha matado estas manos?
+¡No cabe en la muerte un hombre!
+Hay muertos que van subiendo
+cuanto más su ataúd baja...
+¿Quién acostó su estatura
+que su voz está parada?
+
+Hay muertos como raíces
+que hundidas... dan fruto al ala.
+¿Quién ha matado estas manos,
+este sudor, esta cara?
+Hay muertos que van subiendo
+cuanto más su ataúd baja...
+{% end %}

--- a/content/de-otros/ajedrez.md
+++ b/content/de-otros/ajedrez.md
@@ -11,40 +11,44 @@ tags = []
 
 ### I
 
-<div class="poetry">En su grave rincón, los jugadores<br>
-rigen las lentas piezas. El tablero<br>
-los demora hasta el alba en su severo<br>
-ámbito en que se odian dos colores.<br>
-<br>
-Adentro irradian mágicos rigores<br>
-las formas: torre homérica, ligero<br>
-caballo, armada reina, rey postrero,<br>
-oblicuo alfil y peones agresores.<br>
-<br>
-Cuando los jugadores se hayan ido,<br>
-cuando el tiempo los haya consumido,<br>
-ciertamente no habrá cesado el rito.<br>
-<br>
-En el Oriente se encendió esta guerra<br>
-cuyo anfiteatro es hoy toda la tierra.<br>
-Como el otro, este juego es infinito.</div>
+{% poetry() %}
+En su grave rincón, los jugadores
+rigen las lentas piezas. El tablero
+los demora hasta el alba en su severo
+ámbito en que se odian dos colores.
+
+Adentro irradian mágicos rigores
+las formas: torre homérica, ligero
+caballo, armada reina, rey postrero,
+oblicuo alfil y peones agresores.
+
+Cuando los jugadores se hayan ido,
+cuando el tiempo los haya consumido,
+ciertamente no habrá cesado el rito.
+
+En el Oriente se encendió esta guerra
+cuyo anfiteatro es hoy toda la tierra.
+Como el otro, este juego es infinito.
+{% end %}
 
 ### II
 
-<div class="poetry">Tenue rey, sesgo alfil, encarnizada<br>
-reina, torre directa y peón ladino<br>
-sobre lo negro y blanco del camino<br>
-buscan y libran su batalla armada.<br>
-<br>
-No saben que la mano señalada<br>
-del jugador gobierna su destino,<br>
-no saben que un rigor adamantino<br>
-sujeta su albedrío y su jornada.<br>
-<br>
-También el jugador es prisionero<br>
-(la sentencia es de Omar) de otro tablero<br>
-de negras noches y blancos días.<br>
-<br>
-Dios mueve al jugador, y éste, la pieza.<br>
-¿Qué Dios detrás de Dios la trama empieza<br>
-de polvo y tiempo y sueño y agonías?</div>
+{% poetry() %}
+Tenue rey, sesgo alfil, encarnizada
+reina, torre directa y peón ladino
+sobre lo negro y blanco del camino
+buscan y libran su batalla armada.
+
+No saben que la mano señalada
+del jugador gobierna su destino,
+no saben que un rigor adamantino
+sujeta su albedrío y su jornada.
+
+También el jugador es prisionero
+(la sentencia es de Omar) de otro tablero
+de negras noches y blancos días.
+
+Dios mueve al jugador, y éste, la pieza.
+¿Qué Dios detrás de Dios la trama empieza
+de polvo y tiempo y sueño y agonías?
+{% end %}

--- a/content/de-otros/amapola.md
+++ b/content/de-otros/amapola.md
@@ -12,37 +12,39 @@ tags = [
 ]
 +++
 
-<div class="poetry">Abre las hojas del viento, mi vida,<br>
-ponle una montura al río.<br>
-Cabalga y si te da frío te arropas<br>
-con la piel de las estrellas.<br>
-De almohada la luna llena, mi vida,<br>
-y de sueño el amor mío.<br>
-<br>
-Y una amapola me lo dijo ayer,<br>
-que te voy a ver,<br>
-que te voy a ver.<br>
-Y un arcoíris me pintó la piel<br>
-para amanecer contigo.<br>
-<br>
-Cierra la noche y el día, mi vida,<br>
-para que todo sea nuestro.<br>
-Y una gran fuga de besos<br>
-se pose sobre tu boca.<br>
-Y que el trinar de las rosas, mi vida,<br>
-te digan cuanto te quiero.<br>
-<br>
-Y una amapola me lo dijo ayer<br>
-que te voy a ver,<br>
-que te voy a ver.<br>
-Y un arcoíris me pintó la piel<br>
-para amanecer contigo.<br>
-<br>
-Y una amapola me lo dijo ayer<br>
-que te voy a ver,<br>
-que te voy a ver.<br>
-Y un arcoíris me pintó la piel<br>
-para amanecer contigo…</div>
+{% poetry() %}
+Abre las hojas del viento, mi vida,
+ponle una montura al río.
+Cabalga y si te da frío te arropas
+con la piel de las estrellas.
+De almohada la luna llena, mi vida,
+y de sueño el amor mío.
+
+Y una amapola me lo dijo ayer,
+que te voy a ver,
+que te voy a ver.
+Y un arcoíris me pintó la piel
+para amanecer contigo.
+
+Cierra la noche y el día, mi vida,
+para que todo sea nuestro.
+Y una gran fuga de besos
+se pose sobre tu boca.
+Y que el trinar de las rosas, mi vida,
+te digan cuanto te quiero.
+
+Y una amapola me lo dijo ayer
+que te voy a ver,
+que te voy a ver.
+Y un arcoíris me pintó la piel
+para amanecer contigo.
+
+Y una amapola me lo dijo ayer
+que te voy a ver,
+que te voy a ver.
+Y un arcoíris me pintó la piel
+para amanecer contigo…
+{% end %}
 
 {% postscript() %}
 Interpretada por Juan Quintero en [->art399]

--- a/content/de-otros/aurorita.md
+++ b/content/de-otros/aurorita.md
@@ -10,31 +10,33 @@ authors = [
 tags = []
 +++
 
-<div class="poetry">Invierno en la avenida Juan B. Justo<br>
-y el viejo pedaleando en la Aurorita<br>
-rosada de la nena.<br>
-Un pullover y otro y camiseta,<br>
-la campera del Shopping Abasto está muy cara,<br>
-la motito alemana está muy cara,<br>
-la bici con seis cambios japonesa<br>
-también y las monedas<br>
-no son para ir en micro<br>
-sino para el puchero y al destino<br>
-hay que llegar igual.<br>
-Si caminando es lejos<br>
-entonces en la bici rosada de la nena.<br>
-Después de veinte años de baulera<br>
-vuelve a salir al viento .<br>
-Las ruedas chiquititas recién resucitadas.<br>
-No hay más vueltas manzana por el barrio,<br>
-no hay más chocolatines los domingos,<br>
-ahora no es juguete sino tracción a sangre,<br>
-segunda vida útil de transporte,<br>
-reciclado biciclo, tempranito,<br>
-la aurora de otros tiempos,<br>
-la infancia convertida en desencanto,<br>
-la nena limpia baños en Miami<br>
-y el padre, el inmigrante,<br>
-pelado y jubilado,<br>
-trepado a la Aurorita,<br>
-se aleja pedaleando.</div>
+{% poetry() %}
+Invierno en la avenida Juan B. Justo
+y el viejo pedaleando en la Aurorita
+rosada de la nena.
+Un pullover y otro y camiseta,
+la campera del Shopping Abasto está muy cara,
+la motito alemana está muy cara,
+la bici con seis cambios japonesa
+también y las monedas
+no son para ir en micro
+sino para el puchero y al destino
+hay que llegar igual.
+Si caminando es lejos
+entonces en la bici rosada de la nena.
+Después de veinte años de baulera
+vuelve a salir al viento .
+Las ruedas chiquititas recién resucitadas.
+No hay más vueltas manzana por el barrio,
+no hay más chocolatines los domingos,
+ahora no es juguete sino tracción a sangre,
+segunda vida útil de transporte,
+reciclado biciclo, tempranito,
+la aurora de otros tiempos,
+la infancia convertida en desencanto,
+la nena limpia baños en Miami
+y el padre, el inmigrante,
+pelado y jubilado,
+trepado a la Aurorita,
+se aleja pedaleando.
+{% end %}

--- a/content/de-otros/ausencia-de-amor.md
+++ b/content/de-otros/ausencia-de-amor.md
@@ -12,21 +12,23 @@ tags = [
 ]
 +++
 
-<div class="poetry">Cómo será pregunto.<br>
-Cómo será tocarte a mi costado.<br>
-Ando de loco por el aire<br>
-que ando que no ando.<br>
-<br>
-Cómo será acostarme<br>
-en tu país de pechos tan lejano.<br>
-Ando de pobrecristo a tu recuerdo<br>
-clavado, reclavado.<br>
-<br>
-Será ya como sea.<br>
-Tal vez me estalle el cuerpo todo lo que he<br>
-esperado.<br>
-Me comerás entonces dulcemente<br>
-pedazo por pedazo.<br>
-<br>
-Seré lo que debiera.<br>
-Tu pie. Tu mano.</div>
+{% poetry() %}
+Cómo será pregunto.
+Cómo será tocarte a mi costado.
+Ando de loco por el aire
+que ando que no ando.
+
+Cómo será acostarme
+en tu país de pechos tan lejano.
+Ando de pobrecristo a tu recuerdo
+clavado, reclavado.
+
+Será ya como sea.
+Tal vez me estalle el cuerpo todo lo que he
+esperado.
+Me comerás entonces dulcemente
+pedazo por pedazo.
+
+Seré lo que debiera.
+Tu pie. Tu mano.
+{% end %}

--- a/content/de-otros/ayer.md
+++ b/content/de-otros/ayer.md
@@ -10,20 +10,22 @@ authors = [
 tags = []
 +++
 
-<div class="poetry">Ayer pasó el pasado lentamente<br>
-con su vacilación definitiva<br>
-sabiéndote infeliz y a la deriva<br>
-con tus dudas selladas en la frente<br>
-<br>
-ayer pasó el pasado por el puente<br>
-y se llevó tu libertad cautiva<br>
-cambiando su silencio en carne viva<br>
-por tus leves alarmas de inocente<br>
-<br>
-ayer pasó el pasado con su historia<br>
-y su deshilachada incertidumbre/<br>
-con su huella de espanto y de reproche<br>
-<br>
-fue haciendo del dolor una costumbre<br>
-sembrando de fracasos tu memoria<br>
-y dejándote a solas con la noche.</div>
+{% poetry() %}
+Ayer pasó el pasado lentamente
+con su vacilación definitiva
+sabiéndote infeliz y a la deriva
+con tus dudas selladas en la frente
+
+ayer pasó el pasado por el puente
+y se llevó tu libertad cautiva
+cambiando su silencio en carne viva
+por tus leves alarmas de inocente
+
+ayer pasó el pasado con su historia
+y su deshilachada incertidumbre/
+con su huella de espanto y de reproche
+
+fue haciendo del dolor una costumbre
+sembrando de fracasos tu memoria
+y dejándote a solas con la noche.
+{% end %}

--- a/content/de-otros/benditos-malditos-viii.md
+++ b/content/de-otros/benditos-malditos-viii.md
@@ -9,23 +9,25 @@ authors = [
 tags = []
 +++
 
-<div class="poetry">Benditas sean las rubias calentonas<br>
-que se bajan las bragas con cualquiera,<br>
-las niñeras que salen respondonas<br>
-y arrinconan al niño en la escalera,<br>
-<br>
-las enfermeras que suben la fiebre,<br>
-las tetas de pezón hospitalario,<br>
-los gatos que no dan gato por liebre,<br>
-los misterios gozosos del rosario,<br>
-<br>
-los frívolos culitos cariñosos<br>
-que no perdonan los polvos atrasados<br>
-y no juegan a ricos y famosos,<br>
-<br>
-los húmedos chochitos de las putas<br>
-que consuelan a más desconsolados<br>
-que las madres teresas de calcutas.</div>
+{% poetry() %}
+Benditas sean las rubias calentonas
+que se bajan las bragas con cualquiera,
+las niñeras que salen respondonas
+y arrinconan al niño en la escalera,
+
+las enfermeras que suben la fiebre,
+las tetas de pezón hospitalario,
+los gatos que no dan gato por liebre,
+los misterios gozosos del rosario,
+
+los frívolos culitos cariñosos
+que no perdonan los polvos atrasados
+y no juegan a ricos y famosos,
+
+los húmedos chochitos de las putas
+que consuelan a más desconsolados
+que las madres teresas de calcutas.
+{% end %}
 
 {% postscript() %}
 De de su libro de sonetos *"Ciento volando de catorce"*.

--- a/content/de-otros/besos-atras.md
+++ b/content/de-otros/besos-atras.md
@@ -11,30 +11,32 @@ tags = [
 ]
 +++
 
-<div class="poetry">Es olvidar todo este tiempo<br>
-que vendrá<br>
-trayendo un fin.<br>
-Es olvidar todo lo triste<br>
-del sufrir<br>
-que ha de llegar.<br>
-<br>
-Es olvidar,<br>
-llenar vacíos que se irán.<br>
-Guardar palabras, callar<br>
-sueños sin seguir ya<br>
-comenzando el amor<br>
-con el sol cada vez<br>
-agotando el olor<br>
-y seguir.<br>
-<br>
-Yo te amaré besos atrás<br>
-desde este amor<br>
-por otra vez.<br>
-Yo te amaré con el adiós<br>
-lleno de ti,<br>
-pleno de fin.<br>
-<br>
-Sin olvidar...</div>
+{% poetry() %}
+Es olvidar todo este tiempo
+que vendrá
+trayendo un fin.
+Es olvidar todo lo triste
+del sufrir
+que ha de llegar.
+
+Es olvidar,
+llenar vacíos que se irán.
+Guardar palabras, callar
+sueños sin seguir ya
+comenzando el amor
+con el sol cada vez
+agotando el olor
+y seguir.
+
+Yo te amaré besos atrás
+desde este amor
+por otra vez.
+Yo te amaré con el adiós
+lleno de ti,
+pleno de fin.
+
+Sin olvidar...
+{% end %}
 
 {% postscript() %}
 Interpretación inédita de Silvio Rodriguez

--- a/content/de-otros/besos.md
+++ b/content/de-otros/besos.md
@@ -12,67 +12,69 @@ tags = [
 ]
 +++
 
-<div class="poetry">Hay besos que pronuncian por sí solos<br>
-la sentencia de amor condenatoria,<br>
-hay besos que se dan con la mirada<br>
-hay besos que se dan con la memoria.<br>
-<br>
-Hay besos silenciosos, besos nobles<br>
-hay besos enigmáticos, sinceros<br>
-hay besos que se dan sólo las almas<br>
-hay besos por prohibidos, verdaderos.<br>
-<br>
-Hay besos que calcinan y que hieren,<br>
-hay besos que arrebatan los sentidos,<br>
-hay besos misteriosos que han dejado<br>
-mil sueños errantes y perdidos.<br>
-<br>
-Hay besos problemáticos que encierran<br>
-una clave que nadie ha descifrado,<br>
-hay besos que engendran la tragedia<br>
-cuantas rosas en broche han deshojado.<br>
-<br>
-Hay besos perfumados, besos tibios<br>
-que palpitan en íntimos anhelos,<br>
-hay besos que en los labios dejan huellas<br>
-como un campo de sol entre dos hielos.<br>
-<br>
-Hay besos que parecen azucenas<br>
-por sublimes, ingenuos y por puros,<br>
-hay besos traicioneros y cobardes,<br>
-hay besos maldecidos y perjuros.<br>
-<br>
-Judas besa a Jesús y deja impresa<br>
-en su rostro de Dios, la felonía,<br>
-mientras la Magdalena con sus besos<br>
-fortifica piadosa su agonía.<br>
-<br>
-Desde entonces en los besos palpita<br>
-el amor, la traición y los dolores,<br>
-en las bodas humanas se parecen<br>
-a la brisa que juega con las flores.<br>
-<br>
-Hay besos que producen desvaríos<br>
-de amorosa pasión ardiente y loca,<br>
-tú los conoces bien son besos míos<br>
-inventados por mí, para tu boca.<br>
-<br>
-Besos de llama que en rastro impreso<br>
-llevan los surcos de un amor vedado,<br>
-besos de tempestad, salvajes besos<br>
-que solo nuestros labios han probado.<br>
-<br>
-¿Te acuerdas del primero...? Indefinible;<br>
-cubrió tu faz de cárdenos sonrojos<br>
-y en los espasmos de emoción terrible,<br>
-llenaronsé de lágrimas tus ojos.<br>
-<br>
-¿Te acuerdas que una tarde en loco exceso<br>
-te vi celoso imaginando agravios,<br>
-te suspendí en mis brazos... vibró un beso,<br>
-y qué viste después...? Sangre en mis labios.<br>
-<br>
-Yo te enseñe a besar: los besos fríos<br>
-son de impasible corazón de roca,<br>
-yo te enseñé a besar con besos míos<br>
-inventados por mí, para tu boca.</div>
+{% poetry() %}
+Hay besos que pronuncian por sí solos
+la sentencia de amor condenatoria,
+hay besos que se dan con la mirada
+hay besos que se dan con la memoria.
+
+Hay besos silenciosos, besos nobles
+hay besos enigmáticos, sinceros
+hay besos que se dan sólo las almas
+hay besos por prohibidos, verdaderos.
+
+Hay besos que calcinan y que hieren,
+hay besos que arrebatan los sentidos,
+hay besos misteriosos que han dejado
+mil sueños errantes y perdidos.
+
+Hay besos problemáticos que encierran
+una clave que nadie ha descifrado,
+hay besos que engendran la tragedia
+cuantas rosas en broche han deshojado.
+
+Hay besos perfumados, besos tibios
+que palpitan en íntimos anhelos,
+hay besos que en los labios dejan huellas
+como un campo de sol entre dos hielos.
+
+Hay besos que parecen azucenas
+por sublimes, ingenuos y por puros,
+hay besos traicioneros y cobardes,
+hay besos maldecidos y perjuros.
+
+Judas besa a Jesús y deja impresa
+en su rostro de Dios, la felonía,
+mientras la Magdalena con sus besos
+fortifica piadosa su agonía.
+
+Desde entonces en los besos palpita
+el amor, la traición y los dolores,
+en las bodas humanas se parecen
+a la brisa que juega con las flores.
+
+Hay besos que producen desvaríos
+de amorosa pasión ardiente y loca,
+tú los conoces bien son besos míos
+inventados por mí, para tu boca.
+
+Besos de llama que en rastro impreso
+llevan los surcos de un amor vedado,
+besos de tempestad, salvajes besos
+que solo nuestros labios han probado.
+
+¿Te acuerdas del primero...? Indefinible;
+cubrió tu faz de cárdenos sonrojos
+y en los espasmos de emoción terrible,
+llenaronsé de lágrimas tus ojos.
+
+¿Te acuerdas que una tarde en loco exceso
+te vi celoso imaginando agravios,
+te suspendí en mis brazos... vibró un beso,
+y qué viste después...? Sangre en mis labios.
+
+Yo te enseñe a besar: los besos fríos
+son de impasible corazón de roca,
+yo te enseñé a besar con besos míos
+inventados por mí, para tu boca.
+{% end %}

--- a/content/de-otros/bievenida.md
+++ b/content/de-otros/bievenida.md
@@ -10,42 +10,44 @@ authors = [
 tags = []
 +++
 
-<div class="poetry">Se me ocurre que vas a llegar distinta<br>
-no exactamente más linda<br>
-ni más fuerte<br>
-ni más dócil<br>
-ni más cauta<br>
-tan solo que vas a llegar distinta<br>
-como si esta temporada de no verme<br>
-te hubiera sorprendido a vos también<br>
-quizá porque sabes<br>
-cómo te pienso y te enumero<br>
-<br>
-después de todo la nostalgia existe<br>
-aunque no lloremos en los andenes fantasmales<br>
-ni sobre las almohadas de candor<br>
-ni bajo el cielo opaco<br>
-<br>
-yo nostalgio<br>
-tu nostalgias<br>
-y cómo me revienta que él nostalgie<br>
-<br>
-tu rostro es la vanguardia<br>
-tal vez llega primero<br>
-porque lo pinto en las paredes<br>
-con trazos invisibles y seguros<br>
-<br>
-no olvides que tu rostro<br>
-me mira como pueblo<br>
-sonríe y rabia y canta<br>
-como pueblo<br>
-y eso te da una lumbre<br>
-inapagable<br>
-ahora no tengo dudas<br>
-vas a llegar distinta y con señales<br>
-con nuevas<br>
-con hondura<br>
-con franqueza<br>
-<br>
-sé que voy a quererte sin preguntas<br>
-sé que vas a quererme sin respuestas.</div>
+{% poetry() %}
+Se me ocurre que vas a llegar distinta
+no exactamente más linda
+ni más fuerte
+ni más dócil
+ni más cauta
+tan solo que vas a llegar distinta
+como si esta temporada de no verme
+te hubiera sorprendido a vos también
+quizá porque sabes
+cómo te pienso y te enumero
+
+después de todo la nostalgia existe
+aunque no lloremos en los andenes fantasmales
+ni sobre las almohadas de candor
+ni bajo el cielo opaco
+
+yo nostalgio
+tu nostalgias
+y cómo me revienta que él nostalgie
+
+tu rostro es la vanguardia
+tal vez llega primero
+porque lo pinto en las paredes
+con trazos invisibles y seguros
+
+no olvides que tu rostro
+me mira como pueblo
+sonríe y rabia y canta
+como pueblo
+y eso te da una lumbre
+inapagable
+ahora no tengo dudas
+vas a llegar distinta y con señales
+con nuevas
+con hondura
+con franqueza
+
+sé que voy a quererte sin preguntas
+sé que vas a quererme sin respuestas.
+{% end %}

--- a/content/de-otros/cancion-de-amor-contigo.md
+++ b/content/de-otros/cancion-de-amor-contigo.md
@@ -12,40 +12,42 @@ tags = [
 ]
 +++
 
-<div class="poetry">Si debo hacer una caricia,<br>
-preferiría que fuera a ti.<br>
-Si tengo que dar algún beso,<br>
-busco tu boca y lo dejo allí<br>
-<br>
-Si es necesario hacer futuro,<br>
-desde tu cuerpo lo inventaré.<br>
-Si el mundo pide decisiones,<br>
-las tomarás y las tomaré.<br>
-<br>
-Si ando buscando una sonrisa<br>
-sé que en tu rostro la puedo hallar.<br>
-Si ando perdido en esta noche,<br>
-tus ojos claros me han de alumbrar<br>
-<br>
-Si me persigue la lujuria,<br>
-la desbarato con mi puñal,<br>
-pués nuestros cuerpos se entrelazan<br>
-como la charla más natural.<br>
-<br>
-Hay veces en que estás tan lejos<br>
-que me da miedo hasta seguirte,<br>
-y aunque te busco en los reflejos<br>
-del mar, no puedo descubrirte.<br>
-<br>
-Pero si debo elegir rumbo,<br>
-preferiría tu corazón,<br>
-y ensancharía esta palabra<br>
-para que quepa nuestra misión.<br>
-<br>
-Salud y canto para todos<br>
-es la consigna de nuestro amor,<br>
-y será cómplice el hermano<br>
-relampagueante y libertador.</div>
+{% poetry() %}
+Si debo hacer una caricia,
+preferiría que fuera a ti.
+Si tengo que dar algún beso,
+busco tu boca y lo dejo allí
+
+Si es necesario hacer futuro,
+desde tu cuerpo lo inventaré.
+Si el mundo pide decisiones,
+las tomarás y las tomaré.
+
+Si ando buscando una sonrisa
+sé que en tu rostro la puedo hallar.
+Si ando perdido en esta noche,
+tus ojos claros me han de alumbrar
+
+Si me persigue la lujuria,
+la desbarato con mi puñal,
+pués nuestros cuerpos se entrelazan
+como la charla más natural.
+
+Hay veces en que estás tan lejos
+que me da miedo hasta seguirte,
+y aunque te busco en los reflejos
+del mar, no puedo descubrirte.
+
+Pero si debo elegir rumbo,
+preferiría tu corazón,
+y ensancharía esta palabra
+para que quepa nuestra misión.
+
+Salud y canto para todos
+es la consigna de nuestro amor,
+y será cómplice el hermano
+relampagueante y libertador.
+{% end %}
 
 {% postscript() %}
 {{ video_embed(provider="youtube", id="t9BhcgDoMEo") }}

--- a/content/de-otros/cartas-de-amor-que-se-queman.md
+++ b/content/de-otros/cartas-de-amor-que-se-queman.md
@@ -11,40 +11,42 @@ tags = [
 ]
 +++
 
-<div class="poetry">Ay niña no queda nada<br>
-de todo lo que soñamos<br>
-nuestro amor son estas llamas<br>
-que están quemando mis manos<br>
-nuestro amor son estas llamas<br>
-que están quemando mis manos<br>
-<br>
-Son como una ala de luto<br>
-volando papel quemado<br>
-las cartas donde lloraba<br>
-este pecho enamorado<br>
-las cartas donde lloraba<br>
-este pecho enamorado<br>
-<br>
-Flor del olvido<br>
-cartas de amor<br>
-el que las quema no sabe<br>
-que enluta su corazón<br>
-el que las quema no sabe<br>
-que enluta su corazón<br>
-<br>
-Yo no se porque la pena<br>
-por tus ojos se va lejos<br>
-y no se porque los míos<br>
-se van dolidos con ellos<br>
-y no se porque los míos<br>
-se van dolidos con ellos<br>
-<br>
-Cartas de amor que se queman<br>
-flores negras en el viento<br>
-le dejan al que ha querido<br>
-el corazón ceniciento<br>
-le dejan al que ha querido<br>
-el corazón ceniciento</div>
+{% poetry() %}
+Ay niña no queda nada
+de todo lo que soñamos
+nuestro amor son estas llamas
+que están quemando mis manos
+nuestro amor son estas llamas
+que están quemando mis manos
+
+Son como una ala de luto
+volando papel quemado
+las cartas donde lloraba
+este pecho enamorado
+las cartas donde lloraba
+este pecho enamorado
+
+Flor del olvido
+cartas de amor
+el que las quema no sabe
+que enluta su corazón
+el que las quema no sabe
+que enluta su corazón
+
+Yo no se porque la pena
+por tus ojos se va lejos
+y no se porque los míos
+se van dolidos con ellos
+y no se porque los míos
+se van dolidos con ellos
+
+Cartas de amor que se queman
+flores negras en el viento
+le dejan al que ha querido
+el corazón ceniciento
+le dejan al que ha querido
+el corazón ceniciento
+{% end %}
 
 {% postscript() %}
 {{ video_embed(provider="youtube", id="YVSmVZOBW4E") }}

--- a/content/de-otros/chega-de-saudade.md
+++ b/content/de-otros/chega-de-saudade.md
@@ -20,45 +20,47 @@ deck = "<div class=\"poetry\">Vai, minha tristeza<br>\nE diz a ela<br>\nQue sem 
 
 **Basta de saudade**
 
-<div class="poetry">Ve, tristeza mía<br>
-y dile que esto sin ella<br>
-no puede ser<br>
-<br>
-Pedí en una oración<br>
-que ella regrese<br>
-porque no puedo sufrir más<br>
-<br>
-Basta de saudade<br>
-la realidad es que sin ella<br>
-ya no hay más paz<br>
-ya no hay belleza<br>
-sólo hay tristeza<br>
-y melancolía que no se sale<br>
-de mí, no sale<br>
-<br>
-Pero si vuelve<br>
-si ella regresa<br>
-que cosa linda<br>
-que cosa loca<br>
-<br>
-Pues hay menos pececitos<br>
-nadando en el mar<br>
-que los besitos que le daré<br>
-<br>
-Entre mis brazos<br>
-los abrazos serán millones<br>
-apretados así<br>
-pegaditos así<br>
-Abrazos y besitos<br>
-y cariños sin fin<br>
-Es acabar con este asunto<br>
-de que vivas sin mí<br>
-<br>
-No quiero más este asunto<br>
-de que estés lejos así<br>
-<br>
-Vamos a dejar este asunto<br>
-de que vivas lejos de mí</div>
+{% poetry() %}
+Ve, tristeza mía
+y dile que esto sin ella
+no puede ser
+
+Pedí en una oración
+que ella regrese
+porque no puedo sufrir más
+
+Basta de saudade
+la realidad es que sin ella
+ya no hay más paz
+ya no hay belleza
+sólo hay tristeza
+y melancolía que no se sale
+de mí, no sale
+
+Pero si vuelve
+si ella regresa
+que cosa linda
+que cosa loca
+
+Pues hay menos pececitos
+nadando en el mar
+que los besitos que le daré
+
+Entre mis brazos
+los abrazos serán millones
+apretados así
+pegaditos así
+Abrazos y besitos
+y cariños sin fin
+Es acabar con este asunto
+de que vivas sin mí
+
+No quiero más este asunto
+de que estés lejos así
+
+Vamos a dejar este asunto
+de que vivas lejos de mí
+{% end %}
 
 {{ video_embed(provider="youtube", id="guMek3_D6ls") }}
 

--- a/content/de-otros/con-ademas-antiguo.md
+++ b/content/de-otros/con-ademas-antiguo.md
@@ -11,18 +11,20 @@ tags = [
 ]
 +++
 
-<div class="poetry">En el vapor del baño se dibuja<br>
-desnuda y luminosa.<br>
-Ceremoniosamente,<br>
-abre una toalla azul, se inclina<br>
-en una reverencia para el dios<br>
-de toda su belleza.<br>
-El pelo en catarata hacia adelante.<br>
-Lleva suave la toalla hasta la nuca,<br>
-se envuelve la cabeza,<br>
-con ademán antiguo<br>
-tuerce diestra la boa de algodón,<br>
-la enrosca en espiral<br>
-y sin saber siquiera que ha rezado<br>
-se yergue tan hermosa con turbante<br>
-que el solo gesto alumbra la vida cotidiana.</div>
+{% poetry() %}
+En el vapor del baño se dibuja
+desnuda y luminosa.
+Ceremoniosamente,
+abre una toalla azul, se inclina
+en una reverencia para el dios
+de toda su belleza.
+El pelo en catarata hacia adelante.
+Lleva suave la toalla hasta la nuca,
+se envuelve la cabeza,
+con ademán antiguo
+tuerce diestra la boa de algodón,
+la enrosca en espiral
+y sin saber siquiera que ha rezado
+se yergue tan hermosa con turbante
+que el solo gesto alumbra la vida cotidiana.
+{% end %}

--- a/content/de-otros/defensa-de-la-alegria.md
+++ b/content/de-otros/defensa-de-la-alegria.md
@@ -11,39 +11,41 @@ tags = [
 ]
 +++
 
-<div class="poetry">Defender la alegría como una trinchera<br>
-defenderla del escándalo y la rutina<br>
-de la miseria y los miserables<br>
-de las ausencias transitorias<br>
-y las definitivas<br>
-<br>
-defender la alegría como un principio<br>
-defenderla del pasmo y las pesadillas<br>
-de los neutrales y de los neutrones<br>
-de las dulces infamias<br>
-y los graves diagnósticos<br>
-<br>
-defender la alegría como una bandera<br>
-defenderla del rayo y la melancolía<br>
-de los ingenuos y de los canallas<br>
-de la retórica y los paros cardíacos<br>
-de las endemias y las academias<br>
-<br>
-defender la alegría como un destino<br>
-defenderla del fuego y de los bomberos<br>
-de los suicidas y los homicidas<br>
-de las vacaciones y del agobio<br>
-de la obligación de estar alegres<br>
-<br>
-defender la alegría como una certeza<br>
-defenderla del óxido y la roña<br>
-de la famosa pátina del tiempo<br>
-del relente y del oportunismo<br>
-de los proxenetas de la risa<br>
-<br>
-defender la alegría como un derecho<br>
-defenderla de dios y del invierno<br>
-de las mayúsculas y de la muerte<br>
-de los apellidos y las lástimas<br>
-del azar<br>
-y también de la alegría.</div>
+{% poetry() %}
+Defender la alegría como una trinchera
+defenderla del escándalo y la rutina
+de la miseria y los miserables
+de las ausencias transitorias
+y las definitivas
+
+defender la alegría como un principio
+defenderla del pasmo y las pesadillas
+de los neutrales y de los neutrones
+de las dulces infamias
+y los graves diagnósticos
+
+defender la alegría como una bandera
+defenderla del rayo y la melancolía
+de los ingenuos y de los canallas
+de la retórica y los paros cardíacos
+de las endemias y las academias
+
+defender la alegría como un destino
+defenderla del fuego y de los bomberos
+de los suicidas y los homicidas
+de las vacaciones y del agobio
+de la obligación de estar alegres
+
+defender la alegría como una certeza
+defenderla del óxido y la roña
+de la famosa pátina del tiempo
+del relente y del oportunismo
+de los proxenetas de la risa
+
+defender la alegría como un derecho
+defenderla de dios y del invierno
+de las mayúsculas y de la muerte
+de los apellidos y las lástimas
+del azar
+y también de la alegría.
+{% end %}

--- a/content/de-otros/desganas.md
+++ b/content/de-otros/desganas.md
@@ -9,18 +9,20 @@ authors = [
 tags = []
 +++
 
-<div class="poetry">Si cuarenta mil niños sucumben diaramente<br>
-en el purgatorio del hambre y de la sed<br>
-si la tortura de los pobres cuerpos<br>
-envilece una a una a las almas<br>
-y si el poder se ufana de sus cuarentenas<br>
-o si los pobres de solemnidad<br>
-son cada vez menos solemnes y más pobres<br>
-ya es bastante grave<br>
-que un solo hombre<br>
-o una sola mujer<br>
-contemplen distraídos el horizonte neutro<br>
-<br>
-pero en cambio es atroz<br>
-sencillamente atroz<br>
-si es la humanidad la que se encoge de hombros.</div>
+{% poetry() %}
+Si cuarenta mil niños sucumben diaramente
+en el purgatorio del hambre y de la sed
+si la tortura de los pobres cuerpos
+envilece una a una a las almas
+y si el poder se ufana de sus cuarentenas
+o si los pobres de solemnidad
+son cada vez menos solemnes y más pobres
+ya es bastante grave
+que un solo hombre
+o una sola mujer
+contemplen distraídos el horizonte neutro
+
+pero en cambio es atroz
+sencillamente atroz
+si es la humanidad la que se encoge de hombros.
+{% end %}

--- a/content/de-otros/dibaxu-xxi.md
+++ b/content/de-otros/dibaxu-xxi.md
@@ -9,24 +9,28 @@ authors = [
 tags = []
 +++
 
-<div class="poetry">en la noche<br>
-tu vientre detiene astros/<br>
-respira como tierra/<br>
-tu vientre es tierra/<br>
-<br>
-en el trigo de tu vientre<br>
-vuelan pájaros<br>
-que cantan<br>
-en lo que va a venir/</div>
+{% poetry() %}
+en la noche
+tu vientre detiene astros/
+respira como tierra/
+tu vientre es tierra/
+
+en el trigo de tu vientre
+vuelan pájaros
+que cantan
+en lo que va a venir/
+{% end %}
 
 --o--
 
-<div class="poetry">nila nochi<br>
-tu ventre queda astrus/<br>
-respira comu terra/<br>
-tu ventre es terra/<br>
-<br>
-nil trigu di tu ventre<br>
-volan páxarus<br>
-qui cantan<br>
-in lu qui va a venir/</div>
+{% poetry() %}
+nila nochi
+tu ventre queda astrus/
+respira comu terra/
+tu ventre es terra/
+
+nil trigu di tu ventre
+volan páxarus
+qui cantan
+in lu qui va a venir/
+{% end %}

--- a/content/de-otros/dulce-daniela.md
+++ b/content/de-otros/dulce-daniela.md
@@ -9,33 +9,35 @@ authors = [
 tags = []
 +++
 
-<div class="poetry">Ella decide cuando es de día,<br>
-ella maneja el sol<br>
-anda pintando toda la casa<br>
-con trozos de crayón.<br>
-<br>
-Rojo a los muros, verde al oscuro<br>
-sillón del comedor,<br>
-y un póquitito de azul celeste<br>
-aquí en mi corazón.<br>
-<br>
-El amarillo tiñe los vidrios<br>
-y ella no entiende bien<br>
-como es que pierde sus hojas verdes<br>
-el paraíso aquel..<br>
-<br>
-Píntame un árbol que no envejezca,<br>
-pinta en mi habitación,<br>
-un árbol verde con hojas frescas<br>
-pinta con tu crayon;<br>
-que necesito, dulce Daniela,<br>
-alguien que pinte aquí,<br>
-un muro nuevo, píntalo nena,<br>
-pinta dentro de mí.<br>
-<br>
-Que necesito dulce Daniela,<br>
-alguien que pinte aquí,<br>
-un mundo nuevo, píntalo nena,<br>
-pinta dentro de mí.</div>
+{% poetry() %}
+Ella decide cuando es de día,
+ella maneja el sol
+anda pintando toda la casa
+con trozos de crayón.
+
+Rojo a los muros, verde al oscuro
+sillón del comedor,
+y un póquitito de azul celeste
+aquí en mi corazón.
+
+El amarillo tiñe los vidrios
+y ella no entiende bien
+como es que pierde sus hojas verdes
+el paraíso aquel..
+
+Píntame un árbol que no envejezca,
+pinta en mi habitación,
+un árbol verde con hojas frescas
+pinta con tu crayon;
+que necesito, dulce Daniela,
+alguien que pinte aquí,
+un muro nuevo, píntalo nena,
+pinta dentro de mí.
+
+Que necesito dulce Daniela,
+alguien que pinte aquí,
+un mundo nuevo, píntalo nena,
+pinta dentro de mí.
+{% end %}
 
 {{ media_audio(src="/media/mp3/08_-_DULCE_DANIELA.mp3", title="08_-_DULCE_DANIELA.mp3") }}

--- a/content/de-otros/el-enamorado.md
+++ b/content/de-otros/el-enamorado.md
@@ -11,20 +11,22 @@ tags = [
 ]
 +++
 
-<div class="poetry">Lunas, marfiles, instrumentos, rosas,<br>
-lamparas y la linea de Durero,<br>
-las nueve cifras y el cambiante cero,<br>
-debo fingir que existen esas cosas.<br>
-<br>
-Debo fingir que en el pasado fueron<br>
-Persepolis y Roma y que una arena<br>
-sutil midio la suerte de la almena<br>
-que los siglos de hierro deshicieron.<br>
-<br>
-Debo fingir las armas y la pira<br>
-de la epopeya y los pesados mares<br>
-que roen de la tierra los pilares.<br>
-<br>
-Debo fingir que hay otros. Es mentira.<br>
-Solo tu eres. Tu, mi desventura<br>
-y mi ventura, inagotable y pura.</div>
+{% poetry() %}
+Lunas, marfiles, instrumentos, rosas,
+lamparas y la linea de Durero,
+las nueve cifras y el cambiante cero,
+debo fingir que existen esas cosas.
+
+Debo fingir que en el pasado fueron
+Persepolis y Roma y que una arena
+sutil midio la suerte de la almena
+que los siglos de hierro deshicieron.
+
+Debo fingir las armas y la pira
+de la epopeya y los pesados mares
+que roen de la tierra los pilares.
+
+Debo fingir que hay otros. Es mentira.
+Solo tu eres. Tu, mi desventura
+y mi ventura, inagotable y pura.
+{% end %}

--- a/content/de-otros/el-juego-en-que-andamos.md
+++ b/content/de-otros/el-juego-en-que-andamos.md
@@ -11,16 +11,18 @@ tags = [
 ]
 +++
 
-<div class="poetry">Si me dieran a elegir, yo elegiría<br>
-esta salud de saber que estamos muy enfermos,<br>
-esta dicha de andar tan infelices.<br>
-Si me dieran a elegir, yo elegiría<br>
-esta inocencia de no ser un inocente,<br>
-esta pureza en que ando por impuro.<br>
-<br>
-Si me dieran a elegir, yo elegiría<br>
-este amor con que odio,<br>
-esta esperanza que come panes desesperados.<br>
-<br>
-Aquí pasa, señores,<br>
-que me juego la muerte.</div>
+{% poetry() %}
+Si me dieran a elegir, yo elegiría
+esta salud de saber que estamos muy enfermos,
+esta dicha de andar tan infelices.
+Si me dieran a elegir, yo elegiría
+esta inocencia de no ser un inocente,
+esta pureza en que ando por impuro.
+
+Si me dieran a elegir, yo elegiría
+este amor con que odio,
+esta esperanza que come panes desesperados.
+
+Aquí pasa, señores,
+que me juego la muerte.
+{% end %}

--- a/content/de-otros/el-lagarto-esta-llorando.md
+++ b/content/de-otros/el-lagarto-esta-llorando.md
@@ -9,26 +9,28 @@ authors = [
 tags = []
 +++
 
-<div class="poetry">El lagarto está llorando.<br>
-La lagarta está llorando.<br>
-<br>
-El lagarto y la lagarta<br>
-con delantaritos blancos.<br>
-<br>
-Han perdido sin querer<br>
-su anillo de desposados.<br>
-<br>
-¡Ay, su anillito de plomo,<br>
-ay, su anillito plomado!<br>
-<br>
-Un cielo grande y sin gente<br>
-monta en su globo a los pájaros.<br>
-<br>
-El sol, capitán redondo,<br>
-lleva un chaleco de raso.<br>
-<br>
-¡Miradlos qué viejos son!<br>
-¡Qué viejos son los lagartos!<br>
-<br>
-¡Ay cómo lloran y lloran.<br>
-¡ay! ¡ay!, cómo están llorando!</div>
+{% poetry() %}
+El lagarto está llorando.
+La lagarta está llorando.
+
+El lagarto y la lagarta
+con delantaritos blancos.
+
+Han perdido sin querer
+su anillo de desposados.
+
+¡Ay, su anillito de plomo,
+ay, su anillito plomado!
+
+Un cielo grande y sin gente
+monta en su globo a los pájaros.
+
+El sol, capitán redondo,
+lleva un chaleco de raso.
+
+¡Miradlos qué viejos son!
+¡Qué viejos son los lagartos!
+
+¡Ay cómo lloran y lloran.
+¡ay! ¡ay!, cómo están llorando!
+{% end %}

--- a/content/de-otros/el-oso.md
+++ b/content/de-otros/el-oso.md
@@ -10,29 +10,31 @@ tags = [
 ]
 +++
 
-<div class="poetry">En este momento, el corazón de un oso pardo<br>
-late apenas ocho veces por minuto.<br>
-Una pizca de energía que gaste de más<br>
-y no podría salir vivo de este invierno.<br>
-Pero así, en la extrema quietud<br>
-sostiene la existencia.<br>
-En unos meses se lo verá como si nada<br>
-atrapando salmones en el río.<br>
-<br>
-El oso hiberna porque sabe que no puede<br>
-hacerle frente al invierno<br>
-(hay humildad e inteligencia en ese acto).<br>
-Si pudiéramos trazar límites con tanta destreza<br>
-cuando algo se vuelve intransitable:<br>
-suspender el deseo, maniobrar el corazón<br>
-como un perfecto artefacto<br>
-de medición de lo que importa.<br>
-<br>
-El oso un día decide despertar<br>
-y sale ávido del vientre de la roca<br>
-(y el hambre lo primero que come<br>
-es la cabeza del miedo).<br>
-Así, como quien vuelve de un sueño,<br>
-barrer la nieve caída en las palabras<br>
-y decir: ahora, mundo<br>
-sabrás que existo.</div>
+{% poetry() %}
+En este momento, el corazón de un oso pardo
+late apenas ocho veces por minuto.
+Una pizca de energía que gaste de más
+y no podría salir vivo de este invierno.
+Pero así, en la extrema quietud
+sostiene la existencia.
+En unos meses se lo verá como si nada
+atrapando salmones en el río.
+
+El oso hiberna porque sabe que no puede
+hacerle frente al invierno
+(hay humildad e inteligencia en ese acto).
+Si pudiéramos trazar límites con tanta destreza
+cuando algo se vuelve intransitable:
+suspender el deseo, maniobrar el corazón
+como un perfecto artefacto
+de medición de lo que importa.
+
+El oso un día decide despertar
+y sale ávido del vientre de la roca
+(y el hambre lo primero que come
+es la cabeza del miedo).
+Así, como quien vuelve de un sueño,
+barrer la nieve caída en las palabras
+y decir: ahora, mundo
+sabrás que existo.
+{% end %}

--- a/content/de-otros/el-puro-no.md
+++ b/content/de-otros/el-puro-no.md
@@ -9,23 +9,25 @@ authors = [
 tags = []
 +++
 
-<div class="poetry">El No<br>
-el no inóvulo<br>
-el no nonato<br>
-el noo<br>
-el no poslodocosmos de impuros ceros noes que noan noan noan<br>
-y nooan<br>
-y plurimono noan el morbo amorfo noo<br>
-no démono<br>
-no deo<br>
-sin son sin sexo ni órbita<br>
-el yerto inóseo noo en unisolo amódulo<br>
-sin poros ya sin nódulo<br>
-ni yo ni fosa ni hoyo<br>
-el macro no ni polvo<br>
-el no más nada todo<br>
-el puro no<br>
-sin no</div>
+{% poetry() %}
+El No
+el no inóvulo
+el no nonato
+el noo
+el no poslodocosmos de impuros ceros noes que noan noan noan
+y nooan
+y plurimono noan el morbo amorfo noo
+no démono
+no deo
+sin son sin sexo ni órbita
+el yerto inóseo noo en unisolo amódulo
+sin poros ya sin nódulo
+ni yo ni fosa ni hoyo
+el macro no ni polvo
+el no más nada todo
+el puro no
+sin no
+{% end %}
 
 {% postscript() %}
 de *En la masmédula*. Se puede escuchar, en voz de Girondo, [acá](http://www.palabravirtual.com/newvo/2079.php)

--- a/content/de-otros/el-sentimiento-de-la-poesia-en-la.md
+++ b/content/de-otros/el-sentimiento-de-la-poesia-en-la.md
@@ -52,9 +52,11 @@ sospechar que eso se llamaba aliteración:
 Y un final de soneto, escrito después de haber visto
 Buenos Aires de noche, desde el balcón de un décimopiso:
 
-<div class="poetry">y la ciudad parece así, dormida,<br>
-Una pradera nocturnal, florida<br>
-Por un millón de blancas margaritas.</div>
+{% poetry() %}
+y la ciudad parece así, dormida,
+Una pradera nocturnal, florida
+Por un millón de blancas margaritas.
+{% end %}
 
 Bonito ¿no? *Nocturnal*... el pibe ya no le tenía miedo a las
 palabras, aunque todavía no supiera qué hacer con ellas.

--- a/content/de-otros/el-tiempo-esta-despues.md
+++ b/content/de-otros/el-tiempo-esta-despues.md
@@ -11,23 +11,25 @@ tags = [
 ]
 +++
 
-<div class="poetry">La calle Llupes raya al medio encuentra Belvedere<br>
-el tren saluda desde abajo con silbos de tristeza<br>
-aquellas filas infinitas saliendo de Central<br>
-el empedrado está tapado pero allí está<br>
-<br>
-La primavera en aquel barrio se llama soledad<br>
-se llama gritos de ternura pidiendo para entrar<br>
-y en el apuro está lloviendo<br>
-ya no se apretarán mis lágrimas en tus bolsillos<br>
-cambiaste de sacón<br>
-<br>
-Un día nos encontraremos en otro carnaval<br>
-tendremos suerte si aprendemos<br>
-que no hay ningún rincón<br>
-que no hay ningún atracadero<br>
-que pueda disolver en su escondite lo que fuimos<br>
-el tiempo está después.</div>
+{% poetry() %}
+La calle Llupes raya al medio encuentra Belvedere
+el tren saluda desde abajo con silbos de tristeza
+aquellas filas infinitas saliendo de Central
+el empedrado está tapado pero allí está
+
+La primavera en aquel barrio se llama soledad
+se llama gritos de ternura pidiendo para entrar
+y en el apuro está lloviendo
+ya no se apretarán mis lágrimas en tus bolsillos
+cambiaste de sacón
+
+Un día nos encontraremos en otro carnaval
+tendremos suerte si aprendemos
+que no hay ningún rincón
+que no hay ningún atracadero
+que pueda disolver en su escondite lo que fuimos
+el tiempo está después.
+{% end %}
 
 {% postscript() %}
 Interpretación por los músicos cordobeses Lucas Heredia y Gastón Testa

--- a/content/de-otros/ella-sonaba-con-vivir-en-bahia.md
+++ b/content/de-otros/ella-sonaba-con-vivir-en-bahia.md
@@ -10,38 +10,40 @@ authors = [
 tags = []
 +++
 
-<div class="poetry">Ella soñaba con vivir en Bahía,<br>
-pero en San Telmo sobrevivía;<br>
-tomaba clases de teatro independiente<br>
-era feliz mostrando el culo a tanta gente<br>
-inteligente.<br>
-<br>
-Tomaba leche en La Martona de Corrientes<br>
-y se las daba de mujer independiente.<br>
-Siempre jugó a ser una mina esclarecida<br>
-con la política social comprometida;<br>
-era agresiva.<br>
-<br>
-En realidad siempre sintió ser agredida;<br>
-"En este medio todo es causa perdida".<br>
-Mientras su amante resoplando a sus espaldas<br>
-le prometía ser el último en forzarla,<br>
-y rescatarla.<br>
-<br>
-Ella pensaba que era un juego este tormento,<br>
-de abandonarlo todo en busca de otros vientos<br>
-de comenzar de nuevo en medio de otra gente,<br>
-en otra patria y otro cielo diferente;<br>
-era inocente.<br>
-<br>
-Nunca empezó en las que enfrentaron seriamente<br>
-la realidad de ser mujeres del presente;<br>
-después de todo era una joven liberada,<br>
-lo suficientemente bien analizada:<br>
-era freudiana.<br>
-<br>
-Ella jugaba a la heroína de la fiaca<br>
-y hoy hace cinco largos años que era flaca<br>
-manda postales, sin corpiño, bien tostada,<br>
-con cierto tono portugués en la posdata.<br>
-Ya es bahiana, mi Mariana.</div>
+{% poetry() %}
+Ella soñaba con vivir en Bahía,
+pero en San Telmo sobrevivía;
+tomaba clases de teatro independiente
+era feliz mostrando el culo a tanta gente
+inteligente.
+
+Tomaba leche en La Martona de Corrientes
+y se las daba de mujer independiente.
+Siempre jugó a ser una mina esclarecida
+con la política social comprometida;
+era agresiva.
+
+En realidad siempre sintió ser agredida;
+"En este medio todo es causa perdida".
+Mientras su amante resoplando a sus espaldas
+le prometía ser el último en forzarla,
+y rescatarla.
+
+Ella pensaba que era un juego este tormento,
+de abandonarlo todo en busca de otros vientos
+de comenzar de nuevo en medio de otra gente,
+en otra patria y otro cielo diferente;
+era inocente.
+
+Nunca empezó en las que enfrentaron seriamente
+la realidad de ser mujeres del presente;
+después de todo era una joven liberada,
+lo suficientemente bien analizada:
+era freudiana.
+
+Ella jugaba a la heroína de la fiaca
+y hoy hace cinco largos años que era flaca
+manda postales, sin corpiño, bien tostada,
+con cierto tono portugués en la posdata.
+Ya es bahiana, mi Mariana.
+{% end %}

--- a/content/de-otros/en-estos-dias.md
+++ b/content/de-otros/en-estos-dias.md
@@ -13,34 +13,36 @@ tags = []
 <em>A la mujer que amo y me ama</em>
 {{% end %}}
 
-<div class="poetry">En estos días, todo el viento del mundo sopla en tu dirección<br>
-La osa mayor corrige la punta de su cola<br>
-Y te corona con la estrella que guía: la mía<br>
-<br>
-Los mares se han torcido con no poco dolor hacia tus costas<br>
-La lluvia dibuja en tu cabeza la sed de millones de árboles<br>
-Las flores te maldicen muriendo, celosas<br>
-<br>
-En estos días no sale el sol, sino tu rostro<br>
-Y en el silencio, sordo del tiempo, gritan tus ojos<br>
-¡Ay!, de estos días terribles<br>
-¡Ay!, de lo indescriptible<br>
-<br>
-En estos días no hay absolución posible para el hombre<br>
-Para el feroz, la fiera que ruge y canta ciega<br>
-Ese animal remoto que devora y devora primaveras<br>
-<br>
-En estos días no sale el sol, sino tu rostro<br>
-Y en el silencio, sordo del tiempo, gritan tus ojos<br>
-¡Ay!, de estos días terribles<br>
-¡Ay!, del nombre que lleven<br>
-¡Ay!, de cuantos se marchen<br>
-¡Ay!, de cuantos se queden<br>
-<br>
-¡Ay!, de todas las cosas<br>
-Que hinchan este segundo<br>
-¡Ay!, de estos días terribles<br>
-Asesinos del mundo</div>
+{% poetry() %}
+En estos días, todo el viento del mundo sopla en tu dirección
+La osa mayor corrige la punta de su cola
+Y te corona con la estrella que guía: la mía
+
+Los mares se han torcido con no poco dolor hacia tus costas
+La lluvia dibuja en tu cabeza la sed de millones de árboles
+Las flores te maldicen muriendo, celosas
+
+En estos días no sale el sol, sino tu rostro
+Y en el silencio, sordo del tiempo, gritan tus ojos
+¡Ay!, de estos días terribles
+¡Ay!, de lo indescriptible
+
+En estos días no hay absolución posible para el hombre
+Para el feroz, la fiera que ruge y canta ciega
+Ese animal remoto que devora y devora primaveras
+
+En estos días no sale el sol, sino tu rostro
+Y en el silencio, sordo del tiempo, gritan tus ojos
+¡Ay!, de estos días terribles
+¡Ay!, del nombre que lleven
+¡Ay!, de cuantos se marchen
+¡Ay!, de cuantos se queden
+
+¡Ay!, de todas las cosas
+Que hinchan este segundo
+¡Ay!, de estos días terribles
+Asesinos del mundo
+{% end %}
 
 {% postscript() %}
 {{ video_embed(provider="youtube", id="Y-8_qIEEdJU") }}

--- a/content/de-otros/es-tiempo-de-union.md
+++ b/content/de-otros/es-tiempo-de-union.md
@@ -11,28 +11,30 @@ tags = [
 ]
 +++
 
-<div class="poetry">Es tiempo de unión,<br>
-tiempo de que juntemos las manos<br>
-y desafiemos la muerte.<br>
-Las naranjas están dulces en los palos,<br>
-se desgajan pesadas para que tu y yo comamos<br>
-la ternura de la naturaleza.<br>
-<br>
-Es tiempo de decir te quiero<br>
-mientras voy reencontrándote en cada una de tus facciones,<br>
-re-descubriéndote en el follaje, la arena,<br>
-en cada minuto que pasa tic-taqueando por mi lado.<br>
-<br>
-El mundo esta detenido delante de la puerta,<br>
-ancho y grande como un campo que nos espera<br>
-para que corramos sobre su hermosa superficie,<br>
-verde, mullida, tupida, satisfecha con el buen invierno.<br>
-<br>
-Dejemos atrás los escombros, amor<br>
-hay tanto paisaje esperándonos,<br>
-tanto amor en los arboles nudosos<br>
-tanta luz para romper nuestra ceguera<br>
-tanta luz...</div>
+{% poetry() %}
+Es tiempo de unión,
+tiempo de que juntemos las manos
+y desafiemos la muerte.
+Las naranjas están dulces en los palos,
+se desgajan pesadas para que tu y yo comamos
+la ternura de la naturaleza.
+
+Es tiempo de decir te quiero
+mientras voy reencontrándote en cada una de tus facciones,
+re-descubriéndote en el follaje, la arena,
+en cada minuto que pasa tic-taqueando por mi lado.
+
+El mundo esta detenido delante de la puerta,
+ancho y grande como un campo que nos espera
+para que corramos sobre su hermosa superficie,
+verde, mullida, tupida, satisfecha con el buen invierno.
+
+Dejemos atrás los escombros, amor
+hay tanto paisaje esperándonos,
+tanto amor en los arboles nudosos
+tanta luz para romper nuestra ceguera
+tanta luz...
+{% end %}
 
 {% postscript() %}
 Publicado en «Sobre La Grama» (1970-1974)

--- a/content/de-otros/escribo-en-el-olvido.md
+++ b/content/de-otros/escribo-en-el-olvido.md
@@ -9,13 +9,15 @@ authors = [
 tags = []
 +++
 
-<div class="poetry">Escribo en el olvido<br>
-en cada fuego de la noche<br>
-cada rostro de ti.<br>
-Hay una piedra entonces<br>
-donde te acuesto mía,<br>
-ninguno la conoce,<br>
-he fundado pueblos en tu dulzura,<br>
-he sufrido esas cosas,<br>
-eres fuera de mí,<br>
-me perteneces extranjera.</div>
+{% poetry() %}
+Escribo en el olvido
+en cada fuego de la noche
+cada rostro de ti.
+Hay una piedra entonces
+donde te acuesto mía,
+ninguno la conoce,
+he fundado pueblos en tu dulzura,
+he sufrido esas cosas,
+eres fuera de mí,
+me perteneces extranjera.
+{% end %}

--- a/content/de-otros/estoy-contigo.md
+++ b/content/de-otros/estoy-contigo.md
@@ -9,17 +9,19 @@ authors = [
 tags = []
 +++
 
-<div class="poetry">Estoy contigo,<br>
-pero por encima de tu hombro<br>
-me dice adiós tu mano que se aleja.<br>
-<br>
-Entonces yo contengo mi mano<br>
-para que no nos traicione ella también.<br>
-<br>
-E insisto:<br>
-estoy contigo.<br>
-Los innegables títulos del adiós<br>
-abandonan entonces provisoriamente sus derechos.<br>
-<br>
-Y nuestras manos se aquietan<br>
-en las equidistancias de estar juntos.</div>
+{% poetry() %}
+Estoy contigo,
+pero por encima de tu hombro
+me dice adiós tu mano que se aleja.
+
+Entonces yo contengo mi mano
+para que no nos traicione ella también.
+
+E insisto:
+estoy contigo.
+Los innegables títulos del adiós
+abandonan entonces provisoriamente sus derechos.
+
+Y nuestras manos se aquietan
+en las equidistancias de estar juntos.
+{% end %}

--- a/content/de-otros/gente-213.md
+++ b/content/de-otros/gente-213.md
@@ -16,25 +16,27 @@ tags = [
 A mi gente
 {{% end %}}
 
-<div class="poetry">Hay gente que con sólo decir una palabra<br>
-enciende la ilusión y los rosales,<br>
-que con sólo sonreír entre los ojos<br>
-nos invita a viajar por otras zonas<br>
-y nos hace recorrer toda la mágia.<br>
-<br>
-Hay gente que con sólo dar la mano<br>
-rompe la soledad, pone la mesa<br>
-sirve el puchero, coloca guirnaldas.<br>
-Que con sólo empuñar una guitarra<br>
-hace una sinfonía de entrecasa.<br>
-<br>
-Hay gente que con sólo abrir la boca<br>
-llega hasta los confines del alma,<br>
-alimenta una flor, inventa sueños,<br>
-hace cantar al vino en las tinajas<br>
-y se queda después como si nada.<br>
-<br>
-Y uno se va de novio con la vida<br>
-desterrando una muerte solitaria<br>
-pues sabe que a la vuelta de la esquina<br>
-hay gente que es así, tan necesaria.</div>
+{% poetry() %}
+Hay gente que con sólo decir una palabra
+enciende la ilusión y los rosales,
+que con sólo sonreír entre los ojos
+nos invita a viajar por otras zonas
+y nos hace recorrer toda la mágia.
+
+Hay gente que con sólo dar la mano
+rompe la soledad, pone la mesa
+sirve el puchero, coloca guirnaldas.
+Que con sólo empuñar una guitarra
+hace una sinfonía de entrecasa.
+
+Hay gente que con sólo abrir la boca
+llega hasta los confines del alma,
+alimenta una flor, inventa sueños,
+hace cantar al vino en las tinajas
+y se queda después como si nada.
+
+Y uno se va de novio con la vida
+desterrando una muerte solitaria
+pues sabe que a la vuelta de la esquina
+hay gente que es así, tan necesaria.
+{% end %}

--- a/content/de-otros/happy-new-year.md
+++ b/content/de-otros/happy-new-year.md
@@ -11,20 +11,22 @@ tags = [
 ]
 +++
 
-<div class="poetry">Mira, no pido mucho,<br>
-solamente tu mano, tenerla<br>
-como un sapito que duerme así contento.<br>
-Necesito esa puerta que me dabas<br>
-para entrar a tu mundo, ese trocito<br>
-de azúcar verde, de redondo alegre.<br>
-¿No me prestás tu mano en esta noche<br>
-de fìn de año de lechuzas roncas?<br>
-No puedes, por razones técnicas.<br>
-Entonces la tramo en el aire, urdiendo cada dedo,<br>
-el durazno sedoso de la palma<br>
-y el dorso, ese país de azules árboles.<br>
-Así la tomo y la sostengo,<br>
-como si de ello dependiera<br>
-muchísimo del mundo,<br>
-la sucesión de las cuatro estaciones,<br>
-el canto de los gallos, el amor de los hombres.</div>
+{% poetry() %}
+Mira, no pido mucho,
+solamente tu mano, tenerla
+como un sapito que duerme así contento.
+Necesito esa puerta que me dabas
+para entrar a tu mundo, ese trocito
+de azúcar verde, de redondo alegre.
+¿No me prestás tu mano en esta noche
+de fìn de año de lechuzas roncas?
+No puedes, por razones técnicas.
+Entonces la tramo en el aire, urdiendo cada dedo,
+el durazno sedoso de la palma
+y el dorso, ese país de azules árboles.
+Así la tomo y la sostengo,
+como si de ello dependiera
+muchísimo del mundo,
+la sucesión de las cuatro estaciones,
+el canto de los gallos, el amor de los hombres.
+{% end %}

--- a/content/de-otros/hermanos.md
+++ b/content/de-otros/hermanos.md
@@ -11,20 +11,22 @@ tags = [
 ]
 +++
 
-<div class="poetry">Aire, fuego y agua casi sin querer<br>
-alzan las montañas, las dejan caer.<br>
-Rigen los destinos, por allá o aquí<br>
-nunca, nadie, nada te alejará de mí.<br>
-<br>
-Hijo, madre, hermano, toman sin pensar<br>
-sendas diferentes, propios de su andar.<br>
-Y así nomás se quieren, por allá o aquí.<br>
-Nunca, nada, nadie te alejará de mí.<br>
-<br>
-Tiempos y distancias, casi sin razón,<br>
-a veces nos separan y otras veces no.<br>
-No ha desespararte con esta canción,<br>
-nada, nadie, nunca, de mi corazón.</div>
+{% poetry() %}
+Aire, fuego y agua casi sin querer
+alzan las montañas, las dejan caer.
+Rigen los destinos, por allá o aquí
+nunca, nadie, nada te alejará de mí.
+
+Hijo, madre, hermano, toman sin pensar
+sendas diferentes, propios de su andar.
+Y así nomás se quieren, por allá o aquí.
+Nunca, nada, nadie te alejará de mí.
+
+Tiempos y distancias, casi sin razón,
+a veces nos separan y otras veces no.
+No ha desespararte con esta canción,
+nada, nadie, nunca, de mi corazón.
+{% end %}
 
 
 {{ video_embed(provider="youtube", id="4XcUbrCLRDM") }}

--- a/content/de-otros/horal.md
+++ b/content/de-otros/horal.md
@@ -9,13 +9,15 @@ authors = [
 tags = []
 +++
 
-<div class="poetry">El mar se mide por olas,<br>
-el cielo por alas,<br>
-nosotros por lágrimas.<br>
-<br>
-El aire descansa en las hojas,<br>
-el agua en los ojos,<br>
-nosotros en nada.<br>
-<br>
-Parece que hay sales y soles,<br>
-nosotros y nada...</div>
+{% poetry() %}
+El mar se mide por olas,
+el cielo por alas,
+nosotros por lágrimas.
+
+El aire descansa en las hojas,
+el agua en los ojos,
+nosotros en nada.
+
+Parece que hay sales y soles,
+nosotros y nada...
+{% end %}

--- a/content/de-otros/idilio-muerto.md
+++ b/content/de-otros/idilio-muerto.md
@@ -12,20 +12,22 @@ tags = []
 subtitle = "César Vallejo"
 +++
 
-<div class="poetry">Qué estará haciendo esta hora<br>
-mi andina y dulce Rita de junco y capulí;<br>
-ahora que me asfixia Bizancio, y que dormita<br>
-la sangre, como flojo coñac, dentro de mí.<br>
-<br>
-Dónde estarán sus manos que en actitud contrita<br>
-planchaban en las tardes blancuras por venir;<br>
-ahora, en esta lluvia que me quita<br>
-las ganas de vivir.<br>
-<br>
-Qué será de su falda de franela;<br>
-de sus afanes; de su andar;<br>
-de su sabor a cañas de mayo del lugar.<br>
-<br>
-Ha de estarse a la puerta mirando algún celaje,<br>
-y al fin dirá temblando: "¡Qué frío hay...Jesús!"<br>
-y llorará en las tejas un pájaro salvaje.</div>
+{% poetry() %}
+Qué estará haciendo esta hora
+mi andina y dulce Rita de junco y capulí;
+ahora que me asfixia Bizancio, y que dormita
+la sangre, como flojo coñac, dentro de mí.
+
+Dónde estarán sus manos que en actitud contrita
+planchaban en las tardes blancuras por venir;
+ahora, en esta lluvia que me quita
+las ganas de vivir.
+
+Qué será de su falda de franela;
+de sus afanes; de su andar;
+de su sabor a cañas de mayo del lugar.
+
+Ha de estarse a la puerta mirando algún celaje,
+y al fin dirá temblando: "¡Qué frío hay...Jesús!"
+y llorará en las tejas un pájaro salvaje.
+{% end %}

--- a/content/de-otros/la-enamorada.md
+++ b/content/de-otros/la-enamorada.md
@@ -10,34 +10,36 @@ authors = [
 tags = []
 +++
 
-<div class="poetry">Esta lúgubre manía de vivir<br>
-esta recóndita humorada de vivir<br>
-te arrastra alejandra no lo niegues.<br>
-<br>
-Hoy te miraste en el espejo<br>
-y te fue triste estabas sola<br>
-la luz rugía el aire cantaba<br>
-pero tu amado no volvió<br>
-<br>
-Enviarás mensajes sonreirás<br>
-tremolarás tus manos así volverá<br>
-tu amado tan amado<br>
-<br>
-Oyes la demente sirena que lo robó<br>
-el barco con barbas de espuma<br>
-donde murieron las risas<br>
-recuerdas el último abrazo<br>
-oh nada de angustias<br>
-ríe en el pañuelo llora a carcajadas<br>
-pero cierra las puertas de tu rostro<br>
-para que no digan luego<br>
-que aquella mujer enamorada fuiste tú<br>
-<br>
-Te remuerden los días<br>
-te culpan las noches<br>
-te duele la vida tanto tanto<br>
-desesperada ¿adónde vas?<br>
-desesperada ¡nada más!</div>
+{% poetry() %}
+Esta lúgubre manía de vivir
+esta recóndita humorada de vivir
+te arrastra alejandra no lo niegues.
+
+Hoy te miraste en el espejo
+y te fue triste estabas sola
+la luz rugía el aire cantaba
+pero tu amado no volvió
+
+Enviarás mensajes sonreirás
+tremolarás tus manos así volverá
+tu amado tan amado
+
+Oyes la demente sirena que lo robó
+el barco con barbas de espuma
+donde murieron las risas
+recuerdas el último abrazo
+oh nada de angustias
+ríe en el pañuelo llora a carcajadas
+pero cierra las puertas de tu rostro
+para que no digan luego
+que aquella mujer enamorada fuiste tú
+
+Te remuerden los días
+te culpan las noches
+te duele la vida tanto tanto
+desesperada ¿adónde vas?
+desesperada ¡nada más!
+{% end %}
 
 {% postscript() %}
 de *La última inocencia* (1956)

--- a/content/de-otros/la-fauna-embalsamada.md
+++ b/content/de-otros/la-fauna-embalsamada.md
@@ -9,39 +9,41 @@ authors = [
 tags = []
 +++
 
-<div class="poetry">¿esto es un poema?<br>
-¿estar a oscuras sin dormir<br>
-puede ser un poema?<br>
-¿si no hay nada<br>
-puede haber un poema?<br>
-¿si digo que respiro en este cubo negro,<br>
-no es algo ya? ¿no es demasiado?<br>
-¿no es mucho más que esto en realidad?<br>
-busco un silencio quieto entre paredes<br>
-una sola palabra de penumbra<br>
-cualquiera menos noche<br>
-porque noche está sólo permitida<br>
-a los poetas cósmicos<br>
-yo me refiero a este apagón del verbo<br>
-la boca ciega en la sombra de este miércoles<br>
-yo fui -yo quise ser- poeta natural, poeta cósmico<br>
-pero soy un poeta de edificio<br>
-poeta de ascensor<br>
-y no quiero dormir<br>
-quiero estar acostado sin luz en las palabras<br>
-por ejemplo:<br>
-¿adónde están las manos<br>
-de esta pregunta?<br>
-¿cómo es un poema en un departamento a oscuras?<br>
-yo que llamaba mulata, yegua de tinta a la noche<br>
-¿adónde voy a ir?<br>
-¿qué voy a hacer con mi fauna embalsamada<br>
-a las dos menos cuarto sin imagen<br>
-a tientas por el verbo del piso seis sin sueño?<br>
-vendo o alquilo mi fiel cosmogonía,<br>
-cambio sistema solar<br>
-por dos palabras ciertas<br>
-que consigan decir toda mi sombra.</div>
+{% poetry() %}
+¿esto es un poema?
+¿estar a oscuras sin dormir
+puede ser un poema?
+¿si no hay nada
+puede haber un poema?
+¿si digo que respiro en este cubo negro,
+no es algo ya? ¿no es demasiado?
+¿no es mucho más que esto en realidad?
+busco un silencio quieto entre paredes
+una sola palabra de penumbra
+cualquiera menos noche
+porque noche está sólo permitida
+a los poetas cósmicos
+yo me refiero a este apagón del verbo
+la boca ciega en la sombra de este miércoles
+yo fui -yo quise ser- poeta natural, poeta cósmico
+pero soy un poeta de edificio
+poeta de ascensor
+y no quiero dormir
+quiero estar acostado sin luz en las palabras
+por ejemplo:
+¿adónde están las manos
+de esta pregunta?
+¿cómo es un poema en un departamento a oscuras?
+yo que llamaba mulata, yegua de tinta a la noche
+¿adónde voy a ir?
+¿qué voy a hacer con mi fauna embalsamada
+a las dos menos cuarto sin imagen
+a tientas por el verbo del piso seis sin sueño?
+vendo o alquilo mi fiel cosmogonía,
+cambio sistema solar
+por dos palabras ciertas
+que consigan decir toda mi sombra.
+{% end %}
 
 {% postscript() %}
 Publicado en en *Consumidor Final*, Editorial Bajo la Luna, 2003.

--- a/content/de-otros/la-luna-con-gatillo.md
+++ b/content/de-otros/la-luna-con-gatillo.md
@@ -11,137 +11,139 @@ tags = [
 ]
 +++
 
-<div class="poetry">Es preciso que nos entendamos.<br>
-Yo hablo de algo seguro y de algo posible.<br>
-Seguro es que todos coman<br>
-y vivan dignamente<br>
-y es posible saber algún día<br>
-muchas cosas que hoy ignoramos.<br>
-Entonces, es necesario que esto cambie.<br>
-<br>
-El carpintero ha hecho esta mesa<br>
-verdaderamente perfecta<br>
-donde se inclina la niña dorada<br>
-y el celeste padre rezonga.<br>
-Un ebanista, un albañil,<br>
-un herrero, un zapatero,<br>
-también saben lo suyo.<br>
-<br>
-El minero baja a la mina,<br>
-al fondo de la estrella muerta.<br>
-El campesino siembra y siega<br>
-la estrella ya resucitada.<br>
-Todo sería maravilloso<br>
-si cada cual viviera dignamente.<br>
-<br>
-Un poema no es una mesa,<br>
-ni un pan,<br>
-ni un muro,<br>
-ni una silla,<br>
-ni una bota.<br>
-<br>
-Con una mesa,<br>
-con un pan,<br>
-con un muro,<br>
-con una silla,<br>
-con una bota,<br>
-no se puede cambiar el mundo.<br>
-<br>
-Con una carabina,<br>
-con un libro,<br>
-eso es posible.<br>
-<br>
-¿Comprendéis por qué<br>
-el poeta y el soldado<br>
-pueden ser una misma cosa?<br>
-<br>
-He marchado detrás de los obreros lúcidos<br>
-y no me arrepiento.<br>
-Ellos saben lo que quieren<br>
-y yo quiero lo que ellos quieren:<br>
-la libertad, bien entendida.<br>
-<br>
-El poeta es siempre poeta<br>
-pero es bueno que al fin comprenda<br>
-de una manera alegre y terrible<br>
-cuánto mejor sería para todos<br>
-que esto cambiara.<br>
-<br>
-Yo los seguí<br>
-y ellos me siguieron.<br>
-¡Ahí está la cosa!<br>
-<br>
-Cuando haya que lanzar la pólvora<br>
-el hombre lanzará la pólvora.<br>
-Cuando haya que lanzar el libro<br>
-el hombre lanzará el libro.<br>
-De la unión de la pólvora y el libro<br>
-puede brotar la rosa más pura.<br>
-<br>
-Digo al pequeño cura<br>
-y al ateo de rebotica<br>
-y al ensayista,<br>
-al neutral,<br>
-al solemne<br>
-y al frívolo,<br>
-al notario y a la corista,<br>
-al buen enterrador,<br>
-al silencioso vecino del tercero,<br>
-a mi amiga que toca el acordeón:<br>
--Mirad la mosca aplastada<br>
-bajo la campana de vidrio.<br>
-<br>
-No quiero ser la mosca aplastada.<br>
-Tampoco tengo nada que ver con el mono.<br>
-No quiero ser abeja.<br>
-No quiero ser únicamente cigarra.<br>
-Tampoco tengo nada que ver con el mono.<br>
-Yo soy un hombre o quiero ser un verdadero hombre<br>
-y no quiero ser, jamás,<br>
-una mosca aplastada bajo la campana de vidrio.<br>
-<br>
-Ni colmena, ni hormiguero,<br>
-no comparéis a los hombres<br>
-nada más que con los hombres.<br>
-<br>
-Dadle al hombre todo lo que necesite.<br>
-Las pesas para pesar,<br>
-las medidas para medir,<br>
-el pan ganado altivamente,<br>
-la flor del aire,<br>
-el dolor auténtico,<br>
-la alegría sin una mancha.<br>
-<br>
-Tengo derecho al vino,<br>
-al aceite, al Museo,<br>
-a la Enciclopedia Británica,<br>
-a un lugar en el ómnibus,<br>
-a un parque abandonado,<br>
-a un muelle,<br>
-a una azucena,<br>
-a salir,<br>
-a quedarme,<br>
-a bailar sobre la piel<br>
-del Último Hombre Antiguo,<br>
-con mi esqueleto nuevo,<br>
-cubierto con piel nueva<br>
-de hombre flamante.<br>
-<br>
-No puedo cruzarme de brazos<br>
-e interrogar ahora al vacío.<br>
-Me rodean la indignidad<br>
-y el desprecio;<br>
-me amenazan la cárcel y el hambre.<br>
-¡No me dejaré sobornar!<br>
-<br>
-No. No se puede ser libre enteramente<br>
-ni estrictamente digno ahora<br>
-cuando el chacal está a la puerta<br>
-esperando<br>
-que nuestra carne caiga, podrida.<br>
-<br>
-Subiré al cielo,<br>
-le pondré gatillo a la luna<br>
-y desde arriba fusilaré al mundo,<br>
-suavemente,<br>
-para que esto cambie de una vez</div>
+{% poetry() %}
+Es preciso que nos entendamos.
+Yo hablo de algo seguro y de algo posible.
+Seguro es que todos coman
+y vivan dignamente
+y es posible saber algún día
+muchas cosas que hoy ignoramos.
+Entonces, es necesario que esto cambie.
+
+El carpintero ha hecho esta mesa
+verdaderamente perfecta
+donde se inclina la niña dorada
+y el celeste padre rezonga.
+Un ebanista, un albañil,
+un herrero, un zapatero,
+también saben lo suyo.
+
+El minero baja a la mina,
+al fondo de la estrella muerta.
+El campesino siembra y siega
+la estrella ya resucitada.
+Todo sería maravilloso
+si cada cual viviera dignamente.
+
+Un poema no es una mesa,
+ni un pan,
+ni un muro,
+ni una silla,
+ni una bota.
+
+Con una mesa,
+con un pan,
+con un muro,
+con una silla,
+con una bota,
+no se puede cambiar el mundo.
+
+Con una carabina,
+con un libro,
+eso es posible.
+
+¿Comprendéis por qué
+el poeta y el soldado
+pueden ser una misma cosa?
+
+He marchado detrás de los obreros lúcidos
+y no me arrepiento.
+Ellos saben lo que quieren
+y yo quiero lo que ellos quieren:
+la libertad, bien entendida.
+
+El poeta es siempre poeta
+pero es bueno que al fin comprenda
+de una manera alegre y terrible
+cuánto mejor sería para todos
+que esto cambiara.
+
+Yo los seguí
+y ellos me siguieron.
+¡Ahí está la cosa!
+
+Cuando haya que lanzar la pólvora
+el hombre lanzará la pólvora.
+Cuando haya que lanzar el libro
+el hombre lanzará el libro.
+De la unión de la pólvora y el libro
+puede brotar la rosa más pura.
+
+Digo al pequeño cura
+y al ateo de rebotica
+y al ensayista,
+al neutral,
+al solemne
+y al frívolo,
+al notario y a la corista,
+al buen enterrador,
+al silencioso vecino del tercero,
+a mi amiga que toca el acordeón:
+-Mirad la mosca aplastada
+bajo la campana de vidrio.
+
+No quiero ser la mosca aplastada.
+Tampoco tengo nada que ver con el mono.
+No quiero ser abeja.
+No quiero ser únicamente cigarra.
+Tampoco tengo nada que ver con el mono.
+Yo soy un hombre o quiero ser un verdadero hombre
+y no quiero ser, jamás,
+una mosca aplastada bajo la campana de vidrio.
+
+Ni colmena, ni hormiguero,
+no comparéis a los hombres
+nada más que con los hombres.
+
+Dadle al hombre todo lo que necesite.
+Las pesas para pesar,
+las medidas para medir,
+el pan ganado altivamente,
+la flor del aire,
+el dolor auténtico,
+la alegría sin una mancha.
+
+Tengo derecho al vino,
+al aceite, al Museo,
+a la Enciclopedia Británica,
+a un lugar en el ómnibus,
+a un parque abandonado,
+a un muelle,
+a una azucena,
+a salir,
+a quedarme,
+a bailar sobre la piel
+del Último Hombre Antiguo,
+con mi esqueleto nuevo,
+cubierto con piel nueva
+de hombre flamante.
+
+No puedo cruzarme de brazos
+e interrogar ahora al vacío.
+Me rodean la indignidad
+y el desprecio;
+me amenazan la cárcel y el hambre.
+¡No me dejaré sobornar!
+
+No. No se puede ser libre enteramente
+ni estrictamente digno ahora
+cuando el chacal está a la puerta
+esperando
+que nuestra carne caiga, podrida.
+
+Subiré al cielo,
+le pondré gatillo a la luna
+y desde arriba fusilaré al mundo,
+suavemente,
+para que esto cambie de una vez
+{% end %}

--- a/content/de-otros/la-niebla.md
+++ b/content/de-otros/la-niebla.md
@@ -15,34 +15,36 @@ tags = [
 deck = "> A mi abuela Ulita\n\nLa niebla lo invade todo. Este cuarto que no eligió, este mundo que no es el suyo, estos ojos desconocidos que la miran y la buscan, y que aseguran conocerla. Acá la niebla. Más allá, también la niebla.\n\nSobre sus manos viejas como piel de papel, en los ojos alejados, en los huesos de antiguo barro valiente, todavía caminante. Y en el medio de toda la niebla, ella. Ella de espaldas a las ventanas derrumbadas de su presente baldío. De frente al abismo de su pasado, al velatorio continuo de sus memorias desvencijadas, famélicas, suicidas. A veces un sorbo de sol tibio la separa de la niebla y una lucidez con vida de mariposa de dos segundos, desesperada y heroica, consigue traer a sus padres, juntar nombres con rostros, revivir un domingo hecho del tiempo en el que su amor está siempre vivo, en el que siempre hay baile y en donde siempre hay risa, y en donde siempre es feliz como era. Un instante más y la mariposa caerá aplastada bajo el plomo implacable de una niebla invencible. Beso su mejilla, ya incalculablemente distante. Me pregunta quien soy. La niebla, otra vez, lo invade todo."
 +++
 
-<div class="poetry">Solita en un rincón,<br>
-de un tiempo que murió,<br>
-hace algún tiempo atrás,<br>
-sin horas ni reloj.<br>
-Ausente en ese vals<br>
-de cínico compás,<br>
-bailando en un montón<br>
-de niebla y soledad.<br>
-Y yo no sé,<br>
-no sé como llegar,<br>
-y solo sé,<br>
-tan solo sé cantar<br>
-y agradecer<br>
-que puedo recordar<br>
-tus caricias,<br>
-piel de sol y terciopelo.<br>
-Perdida entre tu piel<br>
-se ríe tu niñez,<br>
-se ríe y vos te vas;<br>
-te abrazo donde estés.<br>
-Y yo no sé,<br>
-no sé como llegar,<br>
-y solo sé,<br>
-tan solo sé cantar<br>
-y agradecer<br>
-que pude disfrutar<br>
-de tus mimos de budín<br>
-y caramelo.</div>
+{% poetry() %}
+Solita en un rincón,
+de un tiempo que murió,
+hace algún tiempo atrás,
+sin horas ni reloj.
+Ausente en ese vals
+de cínico compás,
+bailando en un montón
+de niebla y soledad.
+Y yo no sé,
+no sé como llegar,
+y solo sé,
+tan solo sé cantar
+y agradecer
+que puedo recordar
+tus caricias,
+piel de sol y terciopelo.
+Perdida entre tu piel
+se ríe tu niñez,
+se ríe y vos te vas;
+te abrazo donde estés.
+Y yo no sé,
+no sé como llegar,
+y solo sé,
+tan solo sé cantar
+y agradecer
+que pude disfrutar
+de tus mimos de budín
+y caramelo.
+{% end %}
 
 <object width="250" height="150"> <param name="movie" value="http://listen.grooveshark.com/widget.swf"></param> <param name="wmode" value="window"></param> <param name="allowScriptAccess" value="always"></param> <param name="flashvars" value="hostname=cowbell.grooveshark.com&widgetID=20277351&style=metal&bbg=000000&bt=FFFFFF&bfg=666666&p=0"></param> <embed src="http://listen.grooveshark.com/widget.swf" type="application/x-shockwave-flash" width="250" height="150" flashvars="hostname=cowbell.grooveshark.com&widgetID=20277351&style=metal&bbg=000000&bt=FFFFFF&bfg=666666&p=0" allowScriptAccess="always" wmode="window"></embed></object>
 

--- a/content/de-otros/la-suma.md
+++ b/content/de-otros/la-suma.md
@@ -12,17 +12,19 @@ tags = [
 ]
 +++
 
-<div class="poetry">Ante la cal de una pared que nada<br>
-nos veda imaginar como infinita<br>
-un hombre se ha sentado y premedita<br>
-trazar con rigurosa pincelada<br>
-en la blanca pared el mundo entero:<br>
-puertas, balanzas, tártaros, jacintos,<br>
-ángeles, bibliotecas, laberintos,<br>
-anclas, Uxmal, el infinito, el cero.<br>
-Puebla de formas la pared. La suerte,<br>
-que de curiosos dones no es avara,<br>
-le permite dar fin a su porfía.<br>
-En el preciso instante de la muerte<br>
-descubre que esa vasta algarabía<br>
-de líneas es la imagen de su cara.</div>
+{% poetry() %}
+Ante la cal de una pared que nada
+nos veda imaginar como infinita
+un hombre se ha sentado y premedita
+trazar con rigurosa pincelada
+en la blanca pared el mundo entero:
+puertas, balanzas, tártaros, jacintos,
+ángeles, bibliotecas, laberintos,
+anclas, Uxmal, el infinito, el cero.
+Puebla de formas la pared. La suerte,
+que de curiosos dones no es avara,
+le permite dar fin a su porfía.
+En el preciso instante de la muerte
+descubre que esa vasta algarabía
+de líneas es la imagen de su cara.
+{% end %}

--- a/content/de-otros/ligazon-408.md
+++ b/content/de-otros/ligazon-408.md
@@ -9,16 +9,18 @@ authors = [
 tags = []
 +++
 
-<div class="poetry">Ella desnuda y yo desnudo<br>
-y no hay mucho más que me importe.<br>
-Las cosas caen al suelo<br>
-como habiendo estado siempre en ese sitio,<br>
-así caigo yo en ella.<br>
-<br>
-Ella apunta sus rodillas<br>
-hacia dos constelaciones<br>
-y es entonces la pelviana letanía,<br>
-la ligazón oscura con la tierra.</div>
+{% poetry() %}
+Ella desnuda y yo desnudo
+y no hay mucho más que me importe.
+Las cosas caen al suelo
+como habiendo estado siempre en ese sitio,
+así caigo yo en ella.
+
+Ella apunta sus rodillas
+hacia dos constelaciones
+y es entonces la pelviana letanía,
+la ligazón oscura con la tierra.
+{% end %}
 
 {% postscript() %}
 de *Tigre como los Pájaros*, Ediciones Botella al mar, 1996

--- a/content/de-otros/ligazon.md
+++ b/content/de-otros/ligazon.md
@@ -12,13 +12,15 @@ tags = [
 ]
 +++
 
-<div class="poetry">Ella desnuda y yo desnudo<br>
-y no hay mucho más que me importe.<br>
-Las cosas caen al suelo<br>
-como habiendo estado siempre en ese sitio,<br>
-así caigo yo en ella.<br>
-<br>
-Ella apunta sus rodillas<br>
-hacia dos constelaciones<br>
-y es entonces la pelviana letanía,<br>
-la ligazón oscura con la tierra.</div>
+{% poetry() %}
+Ella desnuda y yo desnudo
+y no hay mucho más que me importe.
+Las cosas caen al suelo
+como habiendo estado siempre en ese sitio,
+así caigo yo en ella.
+
+Ella apunta sus rodillas
+hacia dos constelaciones
+y es entonces la pelviana letanía,
+la ligazón oscura con la tierra.
+{% end %}

--- a/content/de-otros/mas-alla-del-amor.md
+++ b/content/de-otros/mas-alla-del-amor.md
@@ -10,34 +10,36 @@ authors = [
 tags = []
 +++
 
-<div class="poetry">Todo nos amenaza:<br>
-el tiempo, que en vivientes fragmentos divide<br>
-al que fui<br>
-del que seré,<br>
-como el machete a la culebra;<br>
-la conciencia, la transparencia traspasada,<br>
-la mirada ciega de mirarse mirar;<br>
-las palabras, guantes grises, polvo mental sobre la yerba,<br>
-el agua, la piel;<br>
-nuestros nombres, que entre tú y yo se levantan,<br>
-murallas de vacío que ninguna trompeta derrumba.<br>
-Ni el sueño y su pueblo de imágenes rotas,<br>
-ni el delirio y su espuma profética,<br>
-ni el amor con sus dientes y uñas nos bastan.<br>
-Más allá de nosotros,<br>
-en las fronteras del ser y el estar,<br>
-una vida más vida nos reclama.<br>
-Afuera la noche respira, se extiende,<br>
-llena de grandes hojas calientes,<br>
-de espejos que combaten:<br>
-frutos, garras, ojos, follajes,<br>
-espaldas que relucen,<br>
-cuerpos que se abren paso entre otros cuerpos.<br>
-Tiéndete aquí a la orilla de tanta espuma,<br>
-de tanta vida que se ignora y se entrega:<br>
-tú también perteneces a la noche.<br>
-Extiéndete, blancura que respira,<br>
-late, oh estrella repartida,<br>
-copa,<br>
-pan que inclinas la balanza del lado de la aurora,<br>
-pausa de sangre entre este tiempo y otro sin medida.</div>
+{% poetry() %}
+Todo nos amenaza:
+el tiempo, que en vivientes fragmentos divide
+al que fui
+del que seré,
+como el machete a la culebra;
+la conciencia, la transparencia traspasada,
+la mirada ciega de mirarse mirar;
+las palabras, guantes grises, polvo mental sobre la yerba,
+el agua, la piel;
+nuestros nombres, que entre tú y yo se levantan,
+murallas de vacío que ninguna trompeta derrumba.
+Ni el sueño y su pueblo de imágenes rotas,
+ni el delirio y su espuma profética,
+ni el amor con sus dientes y uñas nos bastan.
+Más allá de nosotros,
+en las fronteras del ser y el estar,
+una vida más vida nos reclama.
+Afuera la noche respira, se extiende,
+llena de grandes hojas calientes,
+de espejos que combaten:
+frutos, garras, ojos, follajes,
+espaldas que relucen,
+cuerpos que se abren paso entre otros cuerpos.
+Tiéndete aquí a la orilla de tanta espuma,
+de tanta vida que se ignora y se entrega:
+tú también perteneces a la noche.
+Extiéndete, blancura que respira,
+late, oh estrella repartida,
+copa,
+pan que inclinas la balanza del lado de la aurora,
+pausa de sangre entre este tiempo y otro sin medida.
+{% end %}

--- a/content/de-otros/mejor-asi.md
+++ b/content/de-otros/mejor-asi.md
@@ -11,22 +11,24 @@ tags = [
 ]
 +++
 
-<div class="poetry">Sepa que aquí tiene prenda mía<br>
-por si precisa algún día<br>
-el hombro firme, casa en mi pecho<br>
-y la alegría de darte toda la vida.<br>
-<br>
-Yo no tengo nada, te soy sincero<br>
-pero te quiero para acompañarte.<br>
-He de poner el hombro, canto<br>
-y la dicha en quererte tanto<br>
-y darte toda la vida<br>
-<br>
-Mejor así, mejor buscar la manera<br>
-en usar el tiempo que nos queda<br>
-en dar lo que una pueda<br>
-cada uno a su modo, codo a codo<br>
-venga hermano.</div>
+{% poetry() %}
+Sepa que aquí tiene prenda mía
+por si precisa algún día
+el hombro firme, casa en mi pecho
+y la alegría de darte toda la vida.
+
+Yo no tengo nada, te soy sincero
+pero te quiero para acompañarte.
+He de poner el hombro, canto
+y la dicha en quererte tanto
+y darte toda la vida
+
+Mejor así, mejor buscar la manera
+en usar el tiempo que nos queda
+en dar lo que una pueda
+cada uno a su modo, codo a codo
+venga hermano.
+{% end %}
 
 {% postscript() %}
 Grabado en el disco *El matecito de las siete* de Luna Monti y Juan Quintero. La versión en vivo del Ciclo "Esto también está sonando" en la Casa de las Culturas, Resistencia, Chaco - 16/06/12

--- a/content/de-otros/menina-da-lua.md
+++ b/content/de-otros/menina-da-lua.md
@@ -21,26 +21,28 @@ deck = "<div style=\"float:right\">A Nati</div>\n\n<div class=\"poetry\">Leve na
 
 *Mi modesta traducción:*
 
-<div class="poetry">**Niña de luna**<br>
-<br>
-<poesie><br>
-Lleva en la memoria<br>
-esta simple melodía que hice para ti<br>
-mi bien amada<br>
-princesa ojos de agua<br>
-niña de luna<br>
-<br>
-Quiero verte clara<br>
-aclarando la noche intensa de este amor<br>
-el cielo es tu sonrisa<br>
-en el blanco de tu rostro<br>
-que irradia ternura.<br>
-<br>
-Quiero que te desprendas<br>
-de que cualquier temor que sientas<br>
-tienes tu escudo<br>
-y tu telar<br>
-tienes en la mano, querida<br>
-una semilla<br>
-de una flor que inspira un beso ardiente<br>
-una invitación a amar.</div>
+{% poetry() %}
+**Niña de luna**
+
+<poesie>
+Lleva en la memoria
+esta simple melodía que hice para ti
+mi bien amada
+princesa ojos de agua
+niña de luna
+
+Quiero verte clara
+aclarando la noche intensa de este amor
+el cielo es tu sonrisa
+en el blanco de tu rostro
+que irradia ternura.
+
+Quiero que te desprendas
+de que cualquier temor que sientas
+tienes tu escudo
+y tu telar
+tienes en la mano, querida
+una semilla
+de una flor que inspira un beso ardiente
+una invitación a amar.
+{% end %}

--- a/content/de-otros/naranjo-en-flor.md
+++ b/content/de-otros/naranjo-en-flor.md
@@ -12,36 +12,38 @@ tags = [
 ]
 +++
 
-<div class="poetry">Era más blanda que el agua,<br>
-que el agua blanda,<br>
-era más fresca que el río,<br>
-naranjo en flor.<br>
-Y en esa calle de estío,<br>
-calle perdida,<br>
-dejó un pedazo de vida<br>
-y se marchó...<br>
-<br>
-Primero hay que saber sufrir,<br>
-después amar, después partir<br>
-y al fin andar sin pensamiento...<br>
-Perfume de naranjo en flor,<br>
-promesas vanas de un amor<br>
-que se escaparon con el viento.<br>
-Después...¿qué importa el después?<br>
-Toda mi vida es el ayer<br>
-que me detiene en el pasado,<br>
-eterna y vieja juventud<br>
-que me ha dejado acobardado<br>
-como un pájaro sin luz.<br>
-<br>
-¿Qué le habrán hecho mis manos?<br>
-¿Qué le habrán hecho<br>
-para dejarme en el pecho<br>
-tanto dolor?<br>
-Dolor de vieja arboleda,<br>
-canción de esquina<br>
-con un pedazo de vida,<br>
-naranjo en flor.</div>
+{% poetry() %}
+Era más blanda que el agua,
+que el agua blanda,
+era más fresca que el río,
+naranjo en flor.
+Y en esa calle de estío,
+calle perdida,
+dejó un pedazo de vida
+y se marchó...
+
+Primero hay que saber sufrir,
+después amar, después partir
+y al fin andar sin pensamiento...
+Perfume de naranjo en flor,
+promesas vanas de un amor
+que se escaparon con el viento.
+Después...¿qué importa el después?
+Toda mi vida es el ayer
+que me detiene en el pasado,
+eterna y vieja juventud
+que me ha dejado acobardado
+como un pájaro sin luz.
+
+¿Qué le habrán hecho mis manos?
+¿Qué le habrán hecho
+para dejarme en el pecho
+tanto dolor?
+Dolor de vieja arboleda,
+canción de esquina
+con un pedazo de vida,
+naranjo en flor.
+{% end %}
 
 {% postscript() %}
 Interpretación de Juan Carlos Baglietto y el bajista Guido Martínez en el programa *Encuentro en el Estudio*:

--- a/content/de-otros/ninos-corea-1952.md
+++ b/content/de-otros/ninos-corea-1952.md
@@ -14,53 +14,55 @@ tags = [
 deck = "> A Nati, que me acompaña en esta dolorosa tarea de intentar abrir los ojos propios.\n"
 +++
 
-<div class="poetry">Esto que tengo de niño fundamental<br>
-se me rebela, quiere<br>
-llorar en los rincones, desgarrarse<br>
-la frente, la mejilla,<br>
-olvidar el cuaderno donde dice<br>
-mamá con letras tiernas<br>
-y hay una dulce vaca de tres patas.<br>
-<br>
-Hermanitos, ¡qué nunca perseguida<br>
-la vuestra y cómo duele<br>
-aprender a contar como bombarderos<br>
-y el cielo de pizarra!<br>
-¡Cómo duele, hermanitos,<br>
-saberse de memoria la h de hambre<br>
-y saberse la muerte memoria<br>
-y saberse a los yanquis de odio puro,<br>
-cómo duele, hermanitos!<br>
-<br>
-Pienso que te andan castigando el pájaro<br>
-en los ojos, machacándote<br>
-el hueso<br>
-            y me dan ganas<br>
-urgentemente de cuidarte todo!<br>
-defenderse en el aire que te toca!<br>
-<br>
-(No te duermas, niño.<br>
-No te duermas , sol.<br>
-Que en los arrozales<br>
-mata el invasor.<br>
-No te duermas, niño.<br>
-Todavía no....)<br>
-<br>
-Que no y no duermas, párate, hermanito,<br>
-consérvate en tu metro,<br>
-yo sé -- esto que tengo de niño fundamental<br>
-me anda diciendo --<br>
-que estás así,<br>
-en tu leche confirmado.<br>
-peleando con los dedos,<br>
-continuando tu estirpe<br>
-¡y fuera el yanqui!<br>
-¡PAZ!<br>
-¡Paz para tu cuaderno!<br>
-<br>
-Porque puedas y digas<br>
-mamá con letras tiernas<br>
-bajo una dulce vaca de tres patas.</div>
+{% poetry() %}
+Esto que tengo de niño fundamental
+se me rebela, quiere
+llorar en los rincones, desgarrarse
+la frente, la mejilla,
+olvidar el cuaderno donde dice
+mamá con letras tiernas
+y hay una dulce vaca de tres patas.
+
+Hermanitos, ¡qué nunca perseguida
+la vuestra y cómo duele
+aprender a contar como bombarderos
+y el cielo de pizarra!
+¡Cómo duele, hermanitos,
+saberse de memoria la h de hambre
+y saberse la muerte memoria
+y saberse a los yanquis de odio puro,
+cómo duele, hermanitos!
+
+Pienso que te andan castigando el pájaro
+en los ojos, machacándote
+el hueso
+            y me dan ganas
+urgentemente de cuidarte todo!
+defenderse en el aire que te toca!
+
+(No te duermas, niño.
+No te duermas , sol.
+Que en los arrozales
+mata el invasor.
+No te duermas, niño.
+Todavía no....)
+
+Que no y no duermas, párate, hermanito,
+consérvate en tu metro,
+yo sé -- esto que tengo de niño fundamental
+me anda diciendo --
+que estás así,
+en tu leche confirmado.
+peleando con los dedos,
+continuando tu estirpe
+¡y fuera el yanqui!
+¡PAZ!
+¡Paz para tu cuaderno!
+
+Porque puedas y digas
+mamá con letras tiernas
+bajo una dulce vaca de tres patas.
+{% end %}
 
 {% postscript() %}
 Juan Gelman, *Violín y otras cuestiones*, Buenos Aires, 1956.

--- a/content/de-otros/no-amarse-ahora-pero-haber-amado.md
+++ b/content/de-otros/no-amarse-ahora-pero-haber-amado.md
@@ -11,20 +11,22 @@ tags = [
 ]
 +++
 
-<div class="poetry">No amarse ahora, pero haber amado.<br>
-Y encontrarse otra vez... Recuerdo grave<br>
-como el de alguna flor de aroma suave<br>
-que se mustia en un libro ya olvidado.<br>
-<br>
-Va surgiendo el recuerdo desvelado:<br>
-una palabra, un gesto... Es una clave<br>
-que nadie descifró, que nadie sabe;<br>
-recinto nuestro, cántico inviolado.<br>
-<br>
-Estamos en silencio, frente a frente.<br>
-Y sin verte, yo sé que me has mirado<br>
-con no sé qué recuerdo transparente<br>
-<br>
-en los ojos lejanos... No has cambiado.<br>
-Y es dulce estarse así, indolentemente,<br>
-pero no amarse ya. Haberse amado.</div>
+{% poetry() %}
+No amarse ahora, pero haber amado.
+Y encontrarse otra vez... Recuerdo grave
+como el de alguna flor de aroma suave
+que se mustia en un libro ya olvidado.
+
+Va surgiendo el recuerdo desvelado:
+una palabra, un gesto... Es una clave
+que nadie descifró, que nadie sabe;
+recinto nuestro, cántico inviolado.
+
+Estamos en silencio, frente a frente.
+Y sin verte, yo sé que me has mirado
+con no sé qué recuerdo transparente
+
+en los ojos lejanos... No has cambiado.
+Y es dulce estarse así, indolentemente,
+pero no amarse ya. Haberse amado.
+{% end %}

--- a/content/de-otros/no-se-trata-de-hablar.md
+++ b/content/de-otros/no-se-trata-de-hablar.md
@@ -9,15 +9,17 @@ authors = [
 tags = []
 +++
 
-<div class="poetry">No se trata de hablar,<br>
-ni tampoco de callar:<br>
-se trata de abrir algo<br>
-entre la palabra y el silencio.<br>
-Quizá cuando transcurra todo,<br>
-también la palabra y el silencio,<br>
-quede esa zona abierta<br>
-como una esperanza hacia atrás.<br>
-Y tal vez ese signo invertido<br>
-constituya un toque de atención<br>
-para este mutismo ilimitado<br>
-donde palpablemente nos hundimos.</div>
+{% poetry() %}
+No se trata de hablar,
+ni tampoco de callar:
+se trata de abrir algo
+entre la palabra y el silencio.
+Quizá cuando transcurra todo,
+también la palabra y el silencio,
+quede esa zona abierta
+como una esperanza hacia atrás.
+Y tal vez ese signo invertido
+constituya un toque de atención
+para este mutismo ilimitado
+donde palpablemente nos hundimos.
+{% end %}

--- a/content/de-otros/no-te-rindas.md
+++ b/content/de-otros/no-te-rindas.md
@@ -12,46 +12,48 @@ tags = [
 ]
 +++
 
-<div class="poetry">No te rindas, aun estas a tiempo<br>
-de alcanzar y comenzar de nuevo,<br>
-aceptar tus sombras, enterrar tus miedos,<br>
-liberar el lastre, retomar el vuelo.<br>
-<br>
-No te rindas que la vida es eso,<br>
-continuar el viaje,<br>
-perseguir tus sueños,<br>
-destrabar el tiempo,<br>
-correr los escombros y destapar el cielo.<br>
-<br>
-No te rindas, por favor no cedas,<br>
-aunque el frío queme,<br>
-aunque el miedo muerda,<br>
-aunque el sol se esconda y se calle el viento,<br>
-aun hay fuego en tu alma,<br>
-aun hay vida en tus sueños,<br>
-porque la vida es tuya y tuyo también el deseo,<br>
-porque lo has querido y porque te quiero.<br>
-<br>
-Porque existe el vino y el amor, es cierto,<br>
-porque no hay heridas que no cure el tiempo,<br>
-abrir las puertas quitar los cerrojos,<br>
-abandonar las murallas que te protegieron.<br>
-<br>
-Vivir la vida y aceptar el reto,<br>
-recuperar la risa, ensayar el canto,<br>
-bajar la guardia y extender las manos,<br>
-desplegar las alas e intentar de nuevo,<br>
-celebrar la vida y retomar los cielos,<br>
-<br>
-No te rindas por favor no cedas,<br>
-aunque el frío queme,<br>
-aunque el miedo muerda,<br>
-aunque el sol se ponga y se calle el viento,<br>
-aun hay fuego en tu alma,<br>
-aun hay vida en tus sueños,<br>
-porque cada día es un comienzo,<br>
-porque esta es la hora y el mejor momento,<br>
-porque no estas sola,<br>
-porque yo te quiero.</div>
+{% poetry() %}
+No te rindas, aun estas a tiempo
+de alcanzar y comenzar de nuevo,
+aceptar tus sombras, enterrar tus miedos,
+liberar el lastre, retomar el vuelo.
+
+No te rindas que la vida es eso,
+continuar el viaje,
+perseguir tus sueños,
+destrabar el tiempo,
+correr los escombros y destapar el cielo.
+
+No te rindas, por favor no cedas,
+aunque el frío queme,
+aunque el miedo muerda,
+aunque el sol se esconda y se calle el viento,
+aun hay fuego en tu alma,
+aun hay vida en tus sueños,
+porque la vida es tuya y tuyo también el deseo,
+porque lo has querido y porque te quiero.
+
+Porque existe el vino y el amor, es cierto,
+porque no hay heridas que no cure el tiempo,
+abrir las puertas quitar los cerrojos,
+abandonar las murallas que te protegieron.
+
+Vivir la vida y aceptar el reto,
+recuperar la risa, ensayar el canto,
+bajar la guardia y extender las manos,
+desplegar las alas e intentar de nuevo,
+celebrar la vida y retomar los cielos,
+
+No te rindas por favor no cedas,
+aunque el frío queme,
+aunque el miedo muerda,
+aunque el sol se ponga y se calle el viento,
+aun hay fuego en tu alma,
+aun hay vida en tus sueños,
+porque cada día es un comienzo,
+porque esta es la hora y el mejor momento,
+porque no estas sola,
+porque yo te quiero.
+{% end %}
 
 [[No estoy seguro sobre la autoría de este poema, así que acepto la que le asignan algunos foros a Mario Benedetti]]

--- a/content/de-otros/patrias.md
+++ b/content/de-otros/patrias.md
@@ -11,13 +11,15 @@ tags = []
 
 <div style="float:right; align:right"><em> a Olga Orozco </em></div>
 
-<div class="poetry">No importa que no sepas<br>
-cuándo te toca la incandescencia del aire.<br>
-Lo importante es que la recibas<br>
-y más importante aún<br>
-que abras así el país de la bondad.<br>
-Los sueños no saben nada de sí mismos.<br>
-También el aire se ignora y entra<br>
-para hermosearse en tu hermosura.<br>
-En su cristal canta su rostro<br>
-como una patria.</div>
+{% poetry() %}
+No importa que no sepas
+cuándo te toca la incandescencia del aire.
+Lo importante es que la recibas
+y más importante aún
+que abras así el país de la bondad.
+Los sueños no saben nada de sí mismos.
+También el aire se ignora y entra
+para hermosearse en tu hermosura.
+En su cristal canta su rostro
+como una patria.
+{% end %}

--- a/content/de-otros/peluqueria.md
+++ b/content/de-otros/peluqueria.md
@@ -9,22 +9,24 @@ authors = [
 tags = []
 +++
 
-<div class="poetry">En la luz del espejo<br>
-le están cortando el pelo al que yo soy.<br>
-La gran tijera que recorta el día<br>
-roza la yugular, roza la nuca<br>
-con el frío metálico de un arma;<br>
-y el que yo soy me mira porque sabe,<br>
-porque tiene al revés el corazón.<br>
-La voz del locutor<br>
-anuncia una jugada peligrosa,<br>
-el peluquero mira a la pantalla,<br>
-(su equipo va perdiendo)<br>
-me hace una pregunta,<br>
-yo me miro decir que no me gusta el fútbol,<br>
-miro cómo me crecen las orejas<br>
-y en el humor helado, la tijera<br>
-me susurra su tajo.</div>
+{% poetry() %}
+En la luz del espejo
+le están cortando el pelo al que yo soy.
+La gran tijera que recorta el día
+roza la yugular, roza la nuca
+con el frío metálico de un arma;
+y el que yo soy me mira porque sabe,
+porque tiene al revés el corazón.
+La voz del locutor
+anuncia una jugada peligrosa,
+el peluquero mira a la pantalla,
+(su equipo va perdiendo)
+me hace una pregunta,
+yo me miro decir que no me gusta el fútbol,
+miro cómo me crecen las orejas
+y en el humor helado, la tijera
+me susurra su tajo.
+{% end %}
 
 {% postscript() %}
 de *Consumidor Final*, editorial bajo la luna, 2003.

--- a/content/de-otros/poema-no-12-de-espantapajaros.md
+++ b/content/de-otros/poema-no-12-de-espantapajaros.md
@@ -9,27 +9,29 @@ authors = [
 tags = []
 +++
 
-<div class="poetry">Se miran, se presienten, se desean,<br>
-se acarician, se besan, se desnudan,<br>
-se respiran, se acuestan, se olfatean,<br>
-se penetran, se chupan, se demudan,<br>
-se adormecen, despiertan, se iluminan,<br>
-se codician, se palpan, se fascinan,<br>
-se mastican, se gustan, se babean,<br>
-se confunden, se acoplan, se disgregan,<br>
-se aletargan, fallecen, se reintegran,<br>
-se distienden, se enarcan, se menean,<br>
-se retuercen, se estiran, se caldean,<br>
-se estrangulan, se aprietan, se estremecen,<br>
-se tantean, se juntan, desfallecen,<br>
-se repelen, se enervan, se apetecen,<br>
-se acometen, se enlazan, se entrechocan,<br>
-se agazapan, se apresan, se dislocan,<br>
-se perforan, se incrustan, se acribillan,<br>
-se remachan, se injertan, se atornillan,<br>
-se desmayan, reviven, resplandecen,<br>
-se contemplan, se inflaman, se enloquecen,<br>
-se derriten, se sueldan, se calcinan,<br>
-se desgarran, se muerden, se asesinan,<br>
-resucitan, se buscan, se refriegan,<br>
-se rehúyen, se evaden y se entregan.</div>
+{% poetry() %}
+Se miran, se presienten, se desean,
+se acarician, se besan, se desnudan,
+se respiran, se acuestan, se olfatean,
+se penetran, se chupan, se demudan,
+se adormecen, despiertan, se iluminan,
+se codician, se palpan, se fascinan,
+se mastican, se gustan, se babean,
+se confunden, se acoplan, se disgregan,
+se aletargan, fallecen, se reintegran,
+se distienden, se enarcan, se menean,
+se retuercen, se estiran, se caldean,
+se estrangulan, se aprietan, se estremecen,
+se tantean, se juntan, desfallecen,
+se repelen, se enervan, se apetecen,
+se acometen, se enlazan, se entrechocan,
+se agazapan, se apresan, se dislocan,
+se perforan, se incrustan, se acribillan,
+se remachan, se injertan, se atornillan,
+se desmayan, reviven, resplandecen,
+se contemplan, se inflaman, se enloquecen,
+se derriten, se sueldan, se calcinan,
+se desgarran, se muerden, se asesinan,
+resucitan, se buscan, se refriegan,
+se rehúyen, se evaden y se entregan.
+{% end %}

--- a/content/de-otros/poema.md
+++ b/content/de-otros/poema.md
@@ -9,15 +9,17 @@ authors = [
 tags = []
 +++
 
-<div class="poetry">Tu voz<br>
-interrumpe el mundo<br>
-y le da otra palabra. Ahora gira<br>
-en los silencios del sol. Tiene<br>
-mares y tu idea del mar<br>
-es más bella que el mar. Islas<br>
-que son cuando hablás y<br>
-se van cuando callás<br>
-a su isla que se hunde<br>
-en movimientos de mi vida<br>
-y un reloj finge que<br>
-nuestros cuerpos duermen.</div>
+{% poetry() %}
+Tu voz
+interrumpe el mundo
+y le da otra palabra. Ahora gira
+en los silencios del sol. Tiene
+mares y tu idea del mar
+es más bella que el mar. Islas
+que son cuando hablás y
+se van cuando callás
+a su isla que se hunde
+en movimientos de mi vida
+y un reloj finge que
+nuestros cuerpos duermen.
+{% end %}

--- a/content/de-otros/por-eso.md
+++ b/content/de-otros/por-eso.md
@@ -11,20 +11,22 @@ tags = [
 ]
 +++
 
-<div class="poetry">porque yo me desierto y tú me lluvias<br>
-porque me océano y me balsas<br>
-porque me otoño y tú me hojas<br>
-porque me sótano y me alas<br>
-por eso yo te músico y me músicas<br>
-por eso yo te potro y tú me frutas<br>
-y yo te marinero y me tabernas<br>
-y yo te remolino y me lagunas<br>
-por eso yo te circo y tú me infancias<br>
-por eso te amarillo y me amarillas<br>
-y te barco y me arenas<br>
-y te astro y me noches<br>
-y te buzo y me perlas<br>
-y te campo y me flores<br>
-por eso yo te viento y tú me crines<br>
-por eso te crepúsculo y me auroras<br>
-por eso yo te cielo y tú me golondrinas</div>
+{% poetry() %}
+porque yo me desierto y tú me lluvias
+porque me océano y me balsas
+porque me otoño y tú me hojas
+porque me sótano y me alas
+por eso yo te músico y me músicas
+por eso yo te potro y tú me frutas
+y yo te marinero y me tabernas
+y yo te remolino y me lagunas
+por eso yo te circo y tú me infancias
+por eso te amarillo y me amarillas
+y te barco y me arenas
+y te astro y me noches
+y te buzo y me perlas
+y te campo y me flores
+por eso yo te viento y tú me crines
+por eso te crepúsculo y me auroras
+por eso yo te cielo y tú me golondrinas
+{% end %}

--- a/content/de-otros/preguntas.md
+++ b/content/de-otros/preguntas.md
@@ -11,13 +11,15 @@ tags = [
 ]
 +++
 
-<div class="poetry">Ya que navegas por mi sangre y conoces mis límites<br>
-y me despiertas en la mitad del día para acostarme en tu recuerdo<br>
-y eres furia de mi paciencia para mi<br>
-dime qué diablos hago<br>
-por qué te necesito<br>
-quién eres muda sola recorriéndome<br>
-razón de mi pasión<br>
-por qué quiero llenarte solamente de mí<br>
-y abarcarte acabarte mezclarme a tus huesitos<br>
-y eres única patria contra las bestias del olvido</div>
+{% poetry() %}
+Ya que navegas por mi sangre y conoces mis límites
+y me despiertas en la mitad del día para acostarme en tu recuerdo
+y eres furia de mi paciencia para mi
+dime qué diablos hago
+por qué te necesito
+quién eres muda sola recorriéndome
+razón de mi pasión
+por qué quiero llenarte solamente de mí
+y abarcarte acabarte mezclarme a tus huesitos
+y eres única patria contra las bestias del olvido
+{% end %}

--- a/content/de-otros/promesas-sobre-el-bidet.md
+++ b/content/de-otros/promesas-sobre-el-bidet.md
@@ -9,19 +9,21 @@ authors = [
 tags = []
 +++
 
-<div class="poetry">Por favor no hagas promesas sobre el bidet<br>
-por favor no me abras más los sobres.<br>
-Por favor, yo te prometo te escribiré<br>
-si es que para de correr.<br>
-Por favor, sigue la sombra de mi bebé,<br>
-por favor, no bebas más, por favor no llorés.<br>
-Por favor yo te prometo te escribiré si es que para de llover.<br>
-Porque me tratas tan bien, me tratas tan mal<br>
-si sabés que no aprendí a vivir.<br>
-A veces estoy tan bien, estoy tan down.<br>
-Calambres en el alma,<br>
-cada cual tiene un trip en el bocho<br>
-difícil que lleguemos a ponernos de acuerdo.</div>
+{% poetry() %}
+Por favor no hagas promesas sobre el bidet
+por favor no me abras más los sobres.
+Por favor, yo te prometo te escribiré
+si es que para de correr.
+Por favor, sigue la sombra de mi bebé,
+por favor, no bebas más, por favor no llorés.
+Por favor yo te prometo te escribiré si es que para de llover.
+Porque me tratas tan bien, me tratas tan mal
+si sabés que no aprendí a vivir.
+A veces estoy tan bien, estoy tan down.
+Calambres en el alma,
+cada cual tiene un trip en el bocho
+difícil que lleguemos a ponernos de acuerdo.
+{% end %}
 
 {{ video_embed(provider="youtube", id="7oMApe1k-o4") }}
 

--- a/content/de-otros/puente.md
+++ b/content/de-otros/puente.md
@@ -9,22 +9,24 @@ authors = [
 tags = []
 +++
 
-<div class="poetry">¿Lejos?<br>
-<br>
-Hay un arco tendido<br>
-que hace viajar la flecha<br>
-de tu voz.<br>
-<br>
-¿Alto?<br>
-<br>
-Hay un ala que rema<br>
-recta, hacia el sol.<br>
-De polo a polo a una<br>
-secreta información.<br>
-<br>
-¿Qué más?<br>
-<br>
-Estar alerta<br>
-para el duro remar;<br>
-y toda el alma abierta<br>
-de par en par.</div>
+{% poetry() %}
+¿Lejos?
+
+Hay un arco tendido
+que hace viajar la flecha
+de tu voz.
+
+¿Alto?
+
+Hay un ala que rema
+recta, hacia el sol.
+De polo a polo a una
+secreta información.
+
+¿Qué más?
+
+Estar alerta
+para el duro remar;
+y toda el alma abierta
+de par en par.
+{% end %}

--- a/content/de-otros/que-hago-ahora.md
+++ b/content/de-otros/que-hago-ahora.md
@@ -15,28 +15,30 @@ tags = [
 subtitle = "Silvio Rodriguez"
 +++
 
-<div class="poetry">Dónde pongo lo hallado<br>
-en las calles, los libros, las noche,<br>
-los rostros en que te he buscado.<br>
-<br>
-Dónde pongo lo hallado<br>
-en la tierra, en tu nombre, en la Biblia,<br>
-en el día que al fin te he encontrado.<br>
-<br>
-Qué le digo a la muerte tantas veces llamada<br>
-a mi lado que al cabo se ha vuelto mi hermana.<br>
-Qué le digo a la gloria vacía de estar solo<br>
-haciéndome el triste, haciéndome el lobo.<br>
-<br>
-Qué le digo a los perros que se iban conmigo<br>
-en noches pérdidas de estar sin amigos.<br>
-Qué le digo a la luna que creí compañera<br>
-de noches y noches sin ser verdadera.<br>
-<br>
-Qué hago ahora contigo.<br>
-Las palomas que van a dormir a los parques<br>
-ya no hablan conmigo.<br>
-<br>
-Qué hago ahora contigo.<br>
-Ahora que eres la luna, los perros,<br>
-las noches, todos los amigos.</div>
+{% poetry() %}
+Dónde pongo lo hallado
+en las calles, los libros, las noche,
+los rostros en que te he buscado.
+
+Dónde pongo lo hallado
+en la tierra, en tu nombre, en la Biblia,
+en el día que al fin te he encontrado.
+
+Qué le digo a la muerte tantas veces llamada
+a mi lado que al cabo se ha vuelto mi hermana.
+Qué le digo a la gloria vacía de estar solo
+haciéndome el triste, haciéndome el lobo.
+
+Qué le digo a los perros que se iban conmigo
+en noches pérdidas de estar sin amigos.
+Qué le digo a la luna que creí compañera
+de noches y noches sin ser verdadera.
+
+Qué hago ahora contigo.
+Las palomas que van a dormir a los parques
+ya no hablan conmigo.
+
+Qué hago ahora contigo.
+Ahora que eres la luna, los perros,
+las noches, todos los amigos.
+{% end %}

--- a/content/de-otros/rostro-de-vos.md
+++ b/content/de-otros/rostro-de-vos.md
@@ -12,60 +12,62 @@ tags = [
 ]
 +++
 
-<div class="poetry">Tengo una soledad<br>
-tan concurrida<br>
-tan llena de nostalgias<br>
-y de rostros de vos<br>
-de adioses hace tiempo<br>
-y besos bienvenidos<br>
-de primeras de cambio<br>
-y de último vagón.<br>
-<br>
-Tengo una soledad<br>
-tan concurrida<br>
-que puedo organizarla<br>
-como una procesión<br>
-por colores<br>
-tamaños<br>
-y promesas<br>
-por época<br>
-por tacto<br>
-y por sabor.<br>
-<br>
-Sin temblor de más<br>
-me abrazo a tus ausencias<br>
-que asisten y me asisten<br>
-con mi rostro de vos.<br>
-<br>
-Estoy lleno de sombras<br>
-de noches y deseos<br>
-de risas y de alguna<br>
-maldición.<br>
-<br>
-Mis huéspedes concurren<br>
-concurren como sueños<br>
-con sus rencores nuevos<br>
-su falta de candor<br>
-yo les pongo una escoba<br>
-tras la puerta<br>
-porque quiero estar solo<br>
-con mi rostro de vos.<br>
-<br>
-Pero el rostro de vos<br>
-mira a otra parte<br>
-con sus ojos de amor<br>
-que ya no aman<br>
-como víveres<br>
-que buscan su hambre<br>
-miran y miran<br>
-y apagan mi jornada.<br>
-<br>
-Las paredes se van<br>
-queda la noche<br>
-las nostalgias se van<br>
-no queda nada.<br>
-<br>
-Ya mi rostro de vos<br>
-cierra los ojos<br>
-y es una soledad<br>
-tan desolada.</div>
+{% poetry() %}
+Tengo una soledad
+tan concurrida
+tan llena de nostalgias
+y de rostros de vos
+de adioses hace tiempo
+y besos bienvenidos
+de primeras de cambio
+y de último vagón.
+
+Tengo una soledad
+tan concurrida
+que puedo organizarla
+como una procesión
+por colores
+tamaños
+y promesas
+por época
+por tacto
+y por sabor.
+
+Sin temblor de más
+me abrazo a tus ausencias
+que asisten y me asisten
+con mi rostro de vos.
+
+Estoy lleno de sombras
+de noches y deseos
+de risas y de alguna
+maldición.
+
+Mis huéspedes concurren
+concurren como sueños
+con sus rencores nuevos
+su falta de candor
+yo les pongo una escoba
+tras la puerta
+porque quiero estar solo
+con mi rostro de vos.
+
+Pero el rostro de vos
+mira a otra parte
+con sus ojos de amor
+que ya no aman
+como víveres
+que buscan su hambre
+miran y miran
+y apagan mi jornada.
+
+Las paredes se van
+queda la noche
+las nostalgias se van
+no queda nada.
+
+Ya mi rostro de vos
+cierra los ojos
+y es una soledad
+tan desolada.
+{% end %}

--- a/content/de-otros/sanar.md
+++ b/content/de-otros/sanar.md
@@ -11,42 +11,44 @@ tags = [
 ]
 +++
 
-<div class="poetry">Las lágrimas van al cielo<br>
-Y vuelven a tus ojos desde el mar<br>
-El tiempo se va, se va y no vuelve<br>
-Y tu corazón va a sanar<br>
-Va a sanar<br>
-Va a sanar<br>
-<br>
-La tierra parece estar quieta<br>
-Y el sol parece girar,<br>
-Y aunque parezca mentira<br>
-Tu corazón va a sanar<br>
-Va a sanar<br>
-Va a sanar<br>
-Y va a volver a quebrarse<br>
-Mientras le toque pulsar<br>
-<br>
-Y nadie sabe por qué un día el amor nace<br>
-Ni sabe nadie por qué muere el amor un día<br>
-Es que nadie nace sabiendo, nace sabiendo<br>
-Que morir, también es ley de vida.<br>
-<br>
-Así como cuando enfríe<br>
-Van a volver a pasar<br>
-Los pájaros, en bandadas,<br>
-Tu corazón va a sanar<br>
-Va a sanar<br>
-Va a sanar<br>
-<br>
-Y volverás a esperanzarte<br>
-Y luego a desesperar<br>
-Y cuando menos lo esperes<br>
-Tu corazón va a sanar<br>
-Va a sanar<br>
-Va a sanar<br>
-Y va a volver a quebrarse<br>
-Mientras le toque pulsar</div>
+{% poetry() %}
+Las lágrimas van al cielo
+Y vuelven a tus ojos desde el mar
+El tiempo se va, se va y no vuelve
+Y tu corazón va a sanar
+Va a sanar
+Va a sanar
+
+La tierra parece estar quieta
+Y el sol parece girar,
+Y aunque parezca mentira
+Tu corazón va a sanar
+Va a sanar
+Va a sanar
+Y va a volver a quebrarse
+Mientras le toque pulsar
+
+Y nadie sabe por qué un día el amor nace
+Ni sabe nadie por qué muere el amor un día
+Es que nadie nace sabiendo, nace sabiendo
+Que morir, también es ley de vida.
+
+Así como cuando enfríe
+Van a volver a pasar
+Los pájaros, en bandadas,
+Tu corazón va a sanar
+Va a sanar
+Va a sanar
+
+Y volverás a esperanzarte
+Y luego a desesperar
+Y cuando menos lo esperes
+Tu corazón va a sanar
+Va a sanar
+Va a sanar
+Y va a volver a quebrarse
+Mientras le toque pulsar
+{% end %}
 
 {% postscript() %}
 <object width="353" height="132"><embed src="http://www.goear.com/files/external.swf?file=921724f" type="application/x-shockwave-flash" wmode="transparent" quality="high" width="353" height="132"></embed></object>

--- a/content/de-otros/si-toco-todos-los-dias.md
+++ b/content/de-otros/si-toco-todos-los-dias.md
@@ -11,19 +11,21 @@ tags = [
 ]
 +++
 
-<div class="poetry">Si toco todos los días<br>
-este pan, la cama y mis zapatos<br>
-el pie que me adelanta<br>
-y el ojo por donde entra el mundo.<br>
-<br>
-Si con esta visión de la corteza<br>
-adivino al árbol<br>
-y al pájaro que viene.<br>
-<br>
-¿Cómo no voy a conocer<br>
-la exacta dimensión de tu sonrisa<br>
-cuando veas tu nombre<br>
-escrito con mis uñas en los muros?</div>
+{% poetry() %}
+Si toco todos los días
+este pan, la cama y mis zapatos
+el pie que me adelanta
+y el ojo por donde entra el mundo.
+
+Si con esta visión de la corteza
+adivino al árbol
+y al pájaro que viene.
+
+¿Cómo no voy a conocer
+la exacta dimensión de tu sonrisa
+cuando veas tu nombre
+escrito con mis uñas en los muros?
+{% end %}
 
 {% postscript() %}
 Pecas Soriano (1952) es, además de gran poeta, médico de terapia intensiva en el Hospital de Urgencias de la ciudad de Córdoba. A sus pacientes les recita poemas de Roberto Juarróz y [escribe propios en un pizarrón del pasillo del hospital](http://www.diaadia.com.ar/content/un-susurro-en-el-oido-para-aferrarse-la-vida).

--- a/content/de-otros/sin-senal-de-adios.md
+++ b/content/de-otros/sin-senal-de-adios.md
@@ -12,32 +12,34 @@ tags = [
 ]
 +++
 
-<div class="poetry">Qué dulce modo tenés de no estar,<br>
-quédate así cuando te vas,<br>
-como un aroma de sol en la piel<br>
-mucho verano después.<br>
-<br>
-Qué melancólico modo tenés<br>
-de acompañar aunque no estés.<br>
-Tiembla en el aire del atardecer<br>
-verte por última vez.<br>
-<br>
-Tanta vida mía<br>
-desvivir no sé.<br>
-A la lejanía<br>
-me acostumbraré<br>
-pero va por dentro la procesión<br>
-sin señal de adiós.<br>
-<br>
-Qué dulce modo de permanecer,<br>
-cómo me das rumbo y ayer.<br>
-Hago de tanto trabajo de amor<br>
-lágrimas y resplandor.<br>
-<br>
-Honda manera tenés de callar,<br>
-cántame así cuando te vas,<br>
-dejandomé misterioso rumor<br>
-de manantial interior.</div>
+{% poetry() %}
+Qué dulce modo tenés de no estar,
+quédate así cuando te vas,
+como un aroma de sol en la piel
+mucho verano después.
+
+Qué melancólico modo tenés
+de acompañar aunque no estés.
+Tiembla en el aire del atardecer
+verte por última vez.
+
+Tanta vida mía
+desvivir no sé.
+A la lejanía
+me acostumbraré
+pero va por dentro la procesión
+sin señal de adiós.
+
+Qué dulce modo de permanecer,
+cómo me das rumbo y ayer.
+Hago de tanto trabajo de amor
+lágrimas y resplandor.
+
+Honda manera tenés de callar,
+cántame así cuando te vas,
+dejandomé misterioso rumor
+de manantial interior.
+{% end %}
 
 {% postscript() %}
 {{ video_embed(provider="youtube", id="aDqoMR9UYcU") }}

--- a/content/de-otros/soneto-a-tus-visceras.md
+++ b/content/de-otros/soneto-a-tus-visceras.md
@@ -9,20 +9,22 @@ authors = [
 tags = []
 +++
 
-<div class="poetry">Harto ya de alabar tu piel dorada,<br>
-tus externas y muchas perfecciones,<br>
-canto al jardín azul de tus pulmones<br>
-y a tu traquea elegante y anillada.<br>
-<br>
-Canto a tu masa intestinal rosada<br>
-al bazo, al páncreas, a los epiplones,<br>
-al doble filtro gris de tus riñones.<br>
-Y a tu matriz profunda y renovada.<br>
-<br>
-Canto al tuetano dulce de tus huesos,<br>
-a la linfa que embebe tus tejidos,<br>
-al acre olor orgánico que exhalas.<br>
-<br>
-Quiero gastar tus vísceras a besos,<br>
-vivir dentro de ti con mis sentidos…<br>
-yo soy un sapo negro con dos alas.</div>
+{% poetry() %}
+Harto ya de alabar tu piel dorada,
+tus externas y muchas perfecciones,
+canto al jardín azul de tus pulmones
+y a tu traquea elegante y anillada.
+
+Canto a tu masa intestinal rosada
+al bazo, al páncreas, a los epiplones,
+al doble filtro gris de tus riñones.
+Y a tu matriz profunda y renovada.
+
+Canto al tuetano dulce de tus huesos,
+a la linfa que embebe tus tejidos,
+al acre olor orgánico que exhalas.
+
+Quiero gastar tus vísceras a besos,
+vivir dentro de ti con mis sentidos…
+yo soy un sapo negro con dos alas.
+{% end %}

--- a/content/de-otros/sozinho.md
+++ b/content/de-otros/sozinho.md
@@ -18,29 +18,31 @@ deck = "<div class=\"poetry\">Às vezes, no silêncio da noite<br>\nEu fico imag
 
 ### Sozinho - Caetano Veloso
 
-<div class="poetry">A veces, en el silencio de la noche<br>
-Me quedo imaginándonos a los dos<br>
-Me quedo allí soñando despierto, juntando<br>
-El antes, el ahora y el después.<br>
-¿Por qué me dejas tan suelto?<br>
-¿Por qué no me sigues los pasos?<br>
-Me estoy sintiendo muy solo.<br>
-<br>
-No soy ni quiero ser tu dueño<br>
-Es que un cariño a veces cae bien<br>
-Tengo mis deseos y planes secretos<br>
-Que abro para tí y nadie más.<br>
-¿Por qué me olvidas y desapareces?<br>
-¿Y si me interesara por alguien?<br>
-¿Y si ella, de repente, me gana?<br>
-<br>
-Cuando nos gustamos<br>
-Es claro que nos cuidamos<br>
-Dices que me amas<br>
-Sólo que que es de la boca para afuera<br>
-O me engañas<br>
-O no estás madura<br>
-¿Dónde estás ahora?</div>
+{% poetry() %}
+A veces, en el silencio de la noche
+Me quedo imaginándonos a los dos
+Me quedo allí soñando despierto, juntando
+El antes, el ahora y el después.
+¿Por qué me dejas tan suelto?
+¿Por qué no me sigues los pasos?
+Me estoy sintiendo muy solo.
+
+No soy ni quiero ser tu dueño
+Es que un cariño a veces cae bien
+Tengo mis deseos y planes secretos
+Que abro para tí y nadie más.
+¿Por qué me olvidas y desapareces?
+¿Y si me interesara por alguien?
+¿Y si ella, de repente, me gana?
+
+Cuando nos gustamos
+Es claro que nos cuidamos
+Dices que me amas
+Sólo que que es de la boca para afuera
+O me engañas
+O no estás madura
+¿Dónde estás ahora?
+{% end %}
 
 {% postscript() %}
 La rudimentaria traducción es propia, con gentiles correcciones del compañero Quique.

--- a/content/de-otros/suenero.md
+++ b/content/de-otros/suenero.md
@@ -11,55 +11,57 @@ tags = [
 ]
 +++
 
-<div class="poetry">Silbo en la oscuridad<br>
-animal sin reposo<br>
-torres de la vigilia<br>
-candela de los ojos.<br>
-No sé qué pueda ser<br>
-si una curva del tiempo<br>
-o un hueco en el corazón atento  .<br>
-<br>
-Trigo sobre el brocal<br>
-para que coma el hambre<br>
-y abajo el peligroso<br>
-agujero de la sangre<br>
-no hallo, no puedo ver<br>
-mas que la noche alerta<br>
-y el misterio detrás<br>
-de las puertas.<br>
-<br>
-Sueñero, jinete sin descanso;<br>
-sueñero, sobre un papel en blanco<br>
-sueñero, centinela de mi alma,<br>
-sueñero, duérmete y dame calma...<br>
-<br>
-Llevo cada mitad<br>
-como dos ríos gemelos<br>
-uno cruza la tierra<br>
-el otro fluye en el cielo<br>
-el de la oscuridad<br>
-no conoce el olvido<br>
-desvelado en seguir<br>
-lo perdido<br>
-<br>
-Ay, este toro azul,<br>
-fatigado y sediento<br>
-de correr tras la nada<br>
-como la luz y el viento.<br>
-Ardo sin preguntar<br>
-igual que lo hace el fuego<br>
-tal vez halle cantando<br>
-el sosiego.<br>
-<br>
-Sueñero, enigma de un penitente<br>
-sueñero, andando entre los durmientes<br>
-sueñero, espina de las estrellas;<br>
-sueñero, olvidate de ella...<br>
-<br>
-Sueñero, jinete sin descanso<br>
-sueñero, sobre un papel en blanco<br>
-sueñero, centinela de mi alma<br>
-sueñero, duermete y dame calma...</div>
+{% poetry() %}
+Silbo en la oscuridad
+animal sin reposo
+torres de la vigilia
+candela de los ojos.
+No sé qué pueda ser
+si una curva del tiempo
+o un hueco en el corazón atento  .
+
+Trigo sobre el brocal
+para que coma el hambre
+y abajo el peligroso
+agujero de la sangre
+no hallo, no puedo ver
+mas que la noche alerta
+y el misterio detrás
+de las puertas.
+
+Sueñero, jinete sin descanso;
+sueñero, sobre un papel en blanco
+sueñero, centinela de mi alma,
+sueñero, duérmete y dame calma...
+
+Llevo cada mitad
+como dos ríos gemelos
+uno cruza la tierra
+el otro fluye en el cielo
+el de la oscuridad
+no conoce el olvido
+desvelado en seguir
+lo perdido
+
+Ay, este toro azul,
+fatigado y sediento
+de correr tras la nada
+como la luz y el viento.
+Ardo sin preguntar
+igual que lo hace el fuego
+tal vez halle cantando
+el sosiego.
+
+Sueñero, enigma de un penitente
+sueñero, andando entre los durmientes
+sueñero, espina de las estrellas;
+sueñero, olvidate de ella...
+
+Sueñero, jinete sin descanso
+sueñero, sobre un papel en blanco
+sueñero, centinela de mi alma
+sueñero, duermete y dame calma...
+{% end %}
 
 {% postscript() %}
 {{ media_audio(src="/media/mp3/12_-_Suenero.mp3", title="12_-_Suenero.mp3") }}

--- a/content/de-otros/synecdoche-new-york.md
+++ b/content/de-otros/synecdoche-new-york.md
@@ -14,70 +14,72 @@ tags = [
 
 <div style="float:right;">A la memoria de Philip Seymour Hoffman</div>
 
-<div class="poetry">Todo es más complicado de lo que piensas.<br>
-Sólo ves un décimo de lo que es verdad.<br>
-Hay un millón de pequeños hilos<br>
-ligados a cada decisión que tomas.<br>
-<br>
-Puedes destruir tu vida<br>
-cada vez que eliges.<br>
-Pero tal vez no lo sepas<br>
-por veinte años...<br>
-y tal vez nunca jamás<br>
-lo rastrees hasta su origen.<br>
-<br>
-Sólo tienes una oportunidad<br>
-de representarlo.<br>
-<br>
-Intenta comprender tu propio divorcio.<br>
-<br>
-Dicen que no existe el destino,<br>
-pero existe. Es lo que tú creas.<br>
-<br>
-Y aunque el mundo siga girando<br>
-por eones y eones sólo estás aquí por la fracción<br>
-de una fracción de segundo.<br>
-La mayor parte de tu tiempo<br>
-la pasas muerto o aún no nacido.<br>
-<br>
-Pero mientras estás vivo,<br>
-esperas en vano, desperdiciando años,<br>
-por una llamada telefónica<br>
-o una carta o una mirada a alguien o a algo<br>
-para que lo arreglen todo.<br>
-<br>
-Y nunca llega, o parece que sí,<br>
-pero no sucede realmente.<br>
-<br>
-Así que pasas tu tiempo<br>
-en un vago arrepentimiento o<br>
-una aun más vaga esperanza<br>
-de que algo bueno llegue.<br>
-<br>
-Algo que te haga sentir conectado.<br>
-Algo que te haga sentir entero.<br>
-Algo que te haga sentir amado.<br>
-<br>
-Y la verdad es...<br>
-<br>
-que me siento tan enojado.<br>
-que me siento<br>
-tan malditamente triste.<br>
-<br>
-Y la verdad es que me he sentido<br>
-tan herido por tanto puto tiempo.<br>
-<br>
-Y por el mismo tiempo,<br>
-he fingido que estaba bien...<br>
-sólo para poder seguir, sólo para...<br>
-<br>
-No sé por qué.<br>
-<br>
-Tal vez porque nadie<br>
-quiere oír mis desdichas<br>
-porque ellos tienen las suyas.<br>
-<br>
-Bien, a la mierda con todo el mundo.</div>
+{% poetry() %}
+Todo es más complicado de lo que piensas.
+Sólo ves un décimo de lo que es verdad.
+Hay un millón de pequeños hilos
+ligados a cada decisión que tomas.
+
+Puedes destruir tu vida
+cada vez que eliges.
+Pero tal vez no lo sepas
+por veinte años...
+y tal vez nunca jamás
+lo rastrees hasta su origen.
+
+Sólo tienes una oportunidad
+de representarlo.
+
+Intenta comprender tu propio divorcio.
+
+Dicen que no existe el destino,
+pero existe. Es lo que tú creas.
+
+Y aunque el mundo siga girando
+por eones y eones sólo estás aquí por la fracción
+de una fracción de segundo.
+La mayor parte de tu tiempo
+la pasas muerto o aún no nacido.
+
+Pero mientras estás vivo,
+esperas en vano, desperdiciando años,
+por una llamada telefónica
+o una carta o una mirada a alguien o a algo
+para que lo arreglen todo.
+
+Y nunca llega, o parece que sí,
+pero no sucede realmente.
+
+Así que pasas tu tiempo
+en un vago arrepentimiento o
+una aun más vaga esperanza
+de que algo bueno llegue.
+
+Algo que te haga sentir conectado.
+Algo que te haga sentir entero.
+Algo que te haga sentir amado.
+
+Y la verdad es...
+
+que me siento tan enojado.
+que me siento
+tan malditamente triste.
+
+Y la verdad es que me he sentido
+tan herido por tanto puto tiempo.
+
+Y por el mismo tiempo,
+he fingido que estaba bien...
+sólo para poder seguir, sólo para...
+
+No sé por qué.
+
+Tal vez porque nadie
+quiere oír mis desdichas
+porque ellos tienen las suyas.
+
+Bien, a la mierda con todo el mundo.
+{% end %}
 
 {% postscript() %}
 Monólogo del [guión del film](http://dl.opensubtitles.org/en/download/filead/src-api/vrf-8743749ac6/1953384323.gz), en la escena teatral que representa la muerte del padre del protagonista.

--- a/content/de-otros/tu-laberinto.md
+++ b/content/de-otros/tu-laberinto.md
@@ -10,24 +10,26 @@ authors = [
 tags = []
 +++
 
-<div class="poetry">Cuando quieras mi amor, no lo imagines<br>
-no sueñes esperando que lo adivine<br>
-Cuando quieras al fin seguir tu instinto<br>
-ven a verme y abandona tu laberinto<br>
-<br>
-Si no entiendes lo que vives, si no crees lo que dicen,<br>
-Quizás sea porque no puedes sentir tu propio rumbo<br>
-atrapada por el molde que te hicieron que no logras destruir.<br>
-<br>
-Cuando quieras saber quien soy realmente<br>
-permite que tus ojos me lo cuenten<br>
-Cuando quieras mi amor, no te lo niegues<br>
-es tan triste que no tengas y desees.<br>
-<br>
-Cuando quieras mi amor, no lo imagines<br>
-no sueñes esperando que lo adivine.<br>
-Cuando quieras al fin seguir tu instinto<br>
-ven a verme y abandona tu laberinto.</div>
+{% poetry() %}
+Cuando quieras mi amor, no lo imagines
+no sueñes esperando que lo adivine
+Cuando quieras al fin seguir tu instinto
+ven a verme y abandona tu laberinto
+
+Si no entiendes lo que vives, si no crees lo que dicen,
+Quizás sea porque no puedes sentir tu propio rumbo
+atrapada por el molde que te hicieron que no logras destruir.
+
+Cuando quieras saber quien soy realmente
+permite que tus ojos me lo cuenten
+Cuando quieras mi amor, no te lo niegues
+es tan triste que no tengas y desees.
+
+Cuando quieras mi amor, no lo imagines
+no sueñes esperando que lo adivine.
+Cuando quieras al fin seguir tu instinto
+ven a verme y abandona tu laberinto.
+{% end %}
 
 {% postscript() %}
 Interpretación de Liliana Vitale 

--- a/content/de-otros/tu-nombre.md
+++ b/content/de-otros/tu-nombre.md
@@ -9,4 +9,6 @@ authors = [
 tags = []
 +++
 
-<div class="poetry">Trato de escribir en la oscuridad tu nombre. Trato de escribir que te amo. Trato de decir a oscuras esto. No quiero que nadie se entere, que nadie me mire a las tres de la mañana, paseando a lo largo de la estancia, loco, lleno de ti, iluminado, ciego, lleno de ti, derramándote. Digo tu nombre con todo el silencio de la noche, lo grita mi corazón amordazado. Repito tu nombre, vuelvo a decirlo, lo digo incansablemente, y estoy seguro que habrá de amanecer.</div>
+{% poetry() %}
+Trato de escribir en la oscuridad tu nombre. Trato de escribir que te amo. Trato de decir a oscuras esto. No quiero que nadie se entere, que nadie me mire a las tres de la mañana, paseando a lo largo de la estancia, loco, lleno de ti, iluminado, ciego, lleno de ti, derramándote. Digo tu nombre con todo el silencio de la noche, lo grita mi corazón amordazado. Repito tu nombre, vuelvo a decirlo, lo digo incansablemente, y estoy seguro que habrá de amanecer.
+{% end %}

--- a/content/de-otros/un-ruisenor-en-concierto.md
+++ b/content/de-otros/un-ruisenor-en-concierto.md
@@ -12,23 +12,25 @@ tags = [
 ]
 +++
 
-<div class="poetry">En la cima del árbol<br>
-justo al borde del verde<br>
--en donde empieza el aire-<br>
-hay un ruiseñor en concierto.<br>
-<br>
-Por un momento<br>
-creo que soy de nube<br>
-que no me pesa esta materia<br>
-que casi tengo la altura de su canto.<br>
-<br>
-De pronto el ruiseñor<br>
-sostiene al árbol con sus patas<br>
-y sube y sube<br>
-hasta que el cielo es tierra.<br>
-<br>
-¿Quién le puso tanto pájaro<br>
-a esta música?</div>
+{% poetry() %}
+En la cima del árbol
+justo al borde del verde
+-en donde empieza el aire-
+hay un ruiseñor en concierto.
+
+Por un momento
+creo que soy de nube
+que no me pesa esta materia
+que casi tengo la altura de su canto.
+
+De pronto el ruiseñor
+sostiene al árbol con sus patas
+y sube y sube
+hasta que el cielo es tierra.
+
+¿Quién le puso tanto pájaro
+a esta música?
+{% end %}
 
 {% postscript() %}
 Pecas Soriano (1952) es, además de gran poeta, médico de terapia intensiva en el Hospital de Urgencias de la ciudad de Córdoba. A sus pacientes les recita poemas de Roberto Juarróz y [escribe propias en un pizarrón del pasillo del hospital](http://www.diaadia.com.ar/content/un-susurro-en-el-oido-para-aferrarse-la-vida).

--- a/content/de-otros/una-carta-de-amor.md
+++ b/content/de-otros/una-carta-de-amor.md
@@ -11,25 +11,27 @@ tags = [
 ]
 +++
 
-<div class="poetry">Todo lo que de vos quisiera<br>
-es tan poco en el fondo<br>
-porque en el fondo es todo,<br>
-<br>
-como un perro que pasa, una colina,<br>
-esas cosas de nada, cotidianas,<br>
-espiga y cabellera y dos terrones,<br>
-el olor de tu cuerpo,<br>
-lo que decís de cualquier cosa,<br>
-conmigo o contra mía,<br>
-<br>
-todo eso es tan poco,<br>
-yo lo quiero de vos porque te quiero.<br>
-<br>
-Que mires más allá de mí,<br>
-que me ames con violenta prescindencia<br>
-del mañana, que el grito<br>
-de tu entrega se estrelle<br>
-en la cara de un jefe de oficina,<br>
-<br>
-y que el placer que juntos inventamos<br>
-sea otro signo de la libertad.</div>
+{% poetry() %}
+Todo lo que de vos quisiera
+es tan poco en el fondo
+porque en el fondo es todo,
+
+como un perro que pasa, una colina,
+esas cosas de nada, cotidianas,
+espiga y cabellera y dos terrones,
+el olor de tu cuerpo,
+lo que decís de cualquier cosa,
+conmigo o contra mía,
+
+todo eso es tan poco,
+yo lo quiero de vos porque te quiero.
+
+Que mires más allá de mí,
+que me ames con violenta prescindencia
+del mañana, que el grito
+de tu entrega se estrelle
+en la cara de un jefe de oficina,
+
+y que el placer que juntos inventamos
+sea otro signo de la libertad.
+{% end %}

--- a/content/de-otros/una-mujer-y-un-hombre.md
+++ b/content/de-otros/una-mujer-y-un-hombre.md
@@ -11,16 +11,18 @@ tags = [
 ]
 +++
 
-<div class="poetry">Una mujer y un hombre llevados por la vida,<br>
-una mujer y un hombre cara a cara<br>
-habitan en la noche, desbordan por sus manos,<br>
-se oyen subir libres en la sombra,<br>
-sus cabezas descansan en una bella infancia<br>
-que ellos crearon juntos, plena de sol, de luz,<br>
-una mujer y un hombre atados por sus labios<br>
-llenan la noche lenta con toda su memoria,<br>
-una mujer y un hombre más bellos en el otro<br>
-ocupan su lugar en la tierra.</div>
+{% poetry() %}
+Una mujer y un hombre llevados por la vida,
+una mujer y un hombre cara a cara
+habitan en la noche, desbordan por sus manos,
+se oyen subir libres en la sombra,
+sus cabezas descansan en una bella infancia
+que ellos crearon juntos, plena de sol, de luz,
+una mujer y un hombre atados por sus labios
+llenan la noche lenta con toda su memoria,
+una mujer y un hombre más bellos en el otro
+ocupan su lugar en la tierra.
+{% end %}
 
 {% postscript() %}
 de Gotán, 1962.

--- a/content/de-otros/verde-y-azul-325.md
+++ b/content/de-otros/verde-y-azul-325.md
@@ -12,13 +12,15 @@ tags = [
 ]
 +++
 
-<div class="poetry">Ella es el verde y yo el azul.<br>
-Y cuando estamos azul sobre verde<br>
-somos la tierra y el cielo,<br>
-porque ella es la ofrenda fértil<br>
-y yo soy los vientos con tormentas y soles;<br>
-porque ella es la risa, el pan, la tierra<br>
-y yo la senda de los pájaros, el cielo.<br>
-Y así, durante el verde bajo el azul,<br>
-durante el azul sobre el verde,<br>
-somos el mundo.</div>
+{% poetry() %}
+Ella es el verde y yo el azul.
+Y cuando estamos azul sobre verde
+somos la tierra y el cielo,
+porque ella es la ofrenda fértil
+y yo soy los vientos con tormentas y soles;
+porque ella es la risa, el pan, la tierra
+y yo la senda de los pájaros, el cielo.
+Y así, durante el verde bajo el azul,
+durante el azul sobre el verde,
+somos el mundo.
+{% end %}

--- a/content/de-otros/verde-y-azul.md
+++ b/content/de-otros/verde-y-azul.md
@@ -10,13 +10,15 @@ authors = [
 tags = []
 +++
 
-<div class="poetry">Ella es el verde y yo el azul.<br>
-Y cuando estamos azul sobre verde<br>
-somos la tierra y el cielo,<br>
-porque ella es la ofrenda fértil<br>
-y yo soy los vientos con tormentas y soles;<br>
-porque ella es la risa, el pan, la tierra<br>
-y yo la senda de los pájaros, el cielo.<br>
-Y así, durante el verde bajo el azul,<br>
-durante el azul sobre el verde,<br>
-somos el mundo.</div>
+{% poetry() %}
+Ella es el verde y yo el azul.
+Y cuando estamos azul sobre verde
+somos la tierra y el cielo,
+porque ella es la ofrenda fértil
+y yo soy los vientos con tormentas y soles;
+porque ella es la risa, el pan, la tierra
+y yo la senda de los pájaros, el cielo.
+Y así, durante el verde bajo el azul,
+durante el azul sobre el verde,
+somos el mundo.
+{% end %}

--- a/content/de-otros/viento-sur.md
+++ b/content/de-otros/viento-sur.md
@@ -12,42 +12,44 @@ tags = [
 ]
 +++
 
-<div class="poetry">No hay tunel que dure cien años, mi vida. Mira<br>
-como se arruga la tiniebla, la procesión de pálidas<br>
-se desbarranca, los funcionarios inauguran ruinas.<br>
-Y vos y yo fundamos aires buenos.<br>
-<br>
-Donde estará la plata de mi río, solo barro y olitas<br>
-de minué. En los camalotes cantan sirenas, pero<br>
-Ulises camionero no las oye, solo escucha la radio.<br>
-<br>
-Llueve liquen en los decrépitos televisores, buenas<br>
-noches a todos, mariposas y difuntos. Transmiten<br>
-en cadena las cadenas.<br>
-<br>
-El cemento se cansa de ser cobija de la Pampa. Por<br>
-los baches asoma la luz mala, resucitan cardos y<br>
-maíces, abran paso las luciérnagas curiosas que<br>
-verán.<br>
-<br>
-Viento sur, olor a transparencia, silbo de la<br>
-calandria, madrecita cantora del primer rayo de la<br>
-aurora.<br>
-<br>
-La sopa de los pobres llega al centro, y su vapor<br>
-al reino de los cielos.<br>
-<br>
-Ventolina que barre tormentas, lavadero del alma,<br>
-nos deja serenitos, reciclando la pena en vasto<br>
-amor. Silbo de la calandria y vidalita de la<br>
-esperanza.<br>
-<br>
-Darle cuerda al amanecer, empujar un poco al Sol,<br>
-al buen día meterlo en casa. Silba la calandria y<br>
-nos sorprende en vela, amuchados, con ganas de<br>
-seguir.<br>
-<br>
-Estación claridad vamos llegando.</div>
+{% poetry() %}
+No hay tunel que dure cien años, mi vida. Mira
+como se arruga la tiniebla, la procesión de pálidas
+se desbarranca, los funcionarios inauguran ruinas.
+Y vos y yo fundamos aires buenos.
+
+Donde estará la plata de mi río, solo barro y olitas
+de minué. En los camalotes cantan sirenas, pero
+Ulises camionero no las oye, solo escucha la radio.
+
+Llueve liquen en los decrépitos televisores, buenas
+noches a todos, mariposas y difuntos. Transmiten
+en cadena las cadenas.
+
+El cemento se cansa de ser cobija de la Pampa. Por
+los baches asoma la luz mala, resucitan cardos y
+maíces, abran paso las luciérnagas curiosas que
+verán.
+
+Viento sur, olor a transparencia, silbo de la
+calandria, madrecita cantora del primer rayo de la
+aurora.
+
+La sopa de los pobres llega al centro, y su vapor
+al reino de los cielos.
+
+Ventolina que barre tormentas, lavadero del alma,
+nos deja serenitos, reciclando la pena en vasto
+amor. Silbo de la calandria y vidalita de la
+esperanza.
+
+Darle cuerda al amanecer, empujar un poco al Sol,
+al buen día meterlo en casa. Silba la calandria y
+nos sorprende en vela, amuchados, con ganas de
+seguir.
+
+Estación claridad vamos llegando.
+{% end %}
 
 {% postscript() %}
 <object width="353" height="132"><embed src="http://www.goear.com/files/external.swf?file=67d91e8" type="application/x-shockwave-flash" wmode="transparent" quality="high" width="353" height="132"></embed></object>

--- a/content/de-otros/y-el-amor.md
+++ b/content/de-otros/y-el-amor.md
@@ -11,20 +11,22 @@ tags = [
 ]
 +++
 
-<div class="poetry">El milagro de existir,<br>
-el instinto de buscar,<br>
-la fortuna de encontrar,<br>
-el gusto de conocer.<br>
-<br>
-La ilusión de vislumbrar,<br>
-el placer de coincidir,<br>
-el temor a reincidir,<br>
-el orgullo de gustar.<br>
-<br>
-La emoción de desnudar<br>
-y descubrir, despacio, el juego.<br>
-El rito de acariciar prendiendo fuego,<br>
-<br>
-La delicia de encajar y abandonarse,<br>
-el alivio de estallar y derramarse.<br>
-Y el amor...</div>
+{% poetry() %}
+El milagro de existir,
+el instinto de buscar,
+la fortuna de encontrar,
+el gusto de conocer.
+
+La ilusión de vislumbrar,
+el placer de coincidir,
+el temor a reincidir,
+el orgullo de gustar.
+
+La emoción de desnudar
+y descubrir, despacio, el juego.
+El rito de acariciar prendiendo fuego,
+
+La delicia de encajar y abandonarse,
+el alivio de estallar y derramarse.
+Y el amor...
+{% end %}

--- a/content/de-otros/zamba-de-usted.md
+++ b/content/de-otros/zamba-de-usted.md
@@ -13,38 +13,40 @@ tags = [
 ]
 +++
 
-<div class="poetry">Yo no sé<br>
-si podrá<br>
-esta zamba llegar a usted,<br>
-bajo los luceros va por la noche<br>
-buscando el pueblito donde la dejé<br>
-<br>
-Por oír<br>
-otra vez<br>
-la tonadita de su voz,<br>
-niña de los ojos color de olivo<br>
-me iré tras la zamba, romero de amor...<br>
-<br>
-Esta zamba es de usted,<br>
-la hice con nostalgias de piel y de voz,<br>
-cuando usted la escuche crecida en sombra,<br>
-recuérdeme un poco, tan lejos que estoy.<br>
-<br>
-A su pueblo<br>
-yo iré,<br>
-llegaré cuando muera el sol<br>
-en mensajerías de luna y sueño<br>
-para ver, mi niña, si no me olvidó<br>
-<br>
-Soy aquel<br>
-que siguió tras su huella andariega y hoy<br>
-vuelve hasta sus pagos olivareros<br>
-trayendo apenitas su pobre canción.<br>
-<br>
-Esta zamba es de usted,<br>
-la hice con nostalgias de piel y de voz,<br>
-cuando usted la escuche crecida en sombra,<br>
-recuérdeme un poco, tan lejos que estoy.</div>
+{% poetry() %}
+Yo no sé
+si podrá
+esta zamba llegar a usted,
+bajo los luceros va por la noche
+buscando el pueblito donde la dejé
+
+Por oír
+otra vez
+la tonadita de su voz,
+niña de los ojos color de olivo
+me iré tras la zamba, romero de amor...
+
+Esta zamba es de usted,
+la hice con nostalgias de piel y de voz,
+cuando usted la escuche crecida en sombra,
+recuérdeme un poco, tan lejos que estoy.
+
+A su pueblo
+yo iré,
+llegaré cuando muera el sol
+en mensajerías de luna y sueño
+para ver, mi niña, si no me olvidó
+
+Soy aquel
+que siguió tras su huella andariega y hoy
+vuelve hasta sus pagos olivareros
+trayendo apenitas su pobre canción.
+
+Esta zamba es de usted,
+la hice con nostalgias de piel y de voz,
+cuando usted la escuche crecida en sombra,
+recuérdeme un poco, tan lejos que estoy.
+{% end %}
 
 {% postscript() %}
 Interpretación por Micaela Vita y Willy Gonzalez 

--- a/content/videos/aquarela.md
+++ b/content/videos/aquarela.md
@@ -17,56 +17,58 @@ deck = "{{ video_embed(provider=\"youtube\", id=\"2-V21HepcgY\") }}\n\n<div clas
 
 ### Mi traducción 
 
-<div class="poetry">**Acuarela**<br>
-*Toquinho*<br>
-<br>
-En una hoja cualquiera yo dibujo un sol amarillo<br>
-y con cinco o seis rectas es fácil hacer un castillo<br>
-Corro el lápiz alrededor de la mano y me hago guantes<br>
-y si hago llover tengo un paragüas con dos trazos...<br>
-<br>
-Si una gota de tinta cae en un pedacito azul del papel<br>
-en un instante imagino una linda gaviota dispuesta a volar en el cielo...<br>
-Va volando contorneando la inmensa curva del Norte al Sur.<br>
-Pinto un barco a vela blanco navegando,<br>
-y tanto cielo y mar en un bello azul...<br>
-<br>
-Entre las nubes viene surgiendo un lindo avión rosa y granate<br>
-y todo se vuelve colorido destellando sus luces<br>
-<br>
-Basta imaginar que está partiendo, sereno y lindo...<br>
-si nosotros queremos él va a posar.<br>
-<br>
-En una hoja cualquiera yo dibujo un barco de partida<br>
-con algunos buenos amigos bebiendo bien con la vida...<br>
-<br>
-De una América a otra yo consigo pasar en un segundo<br>
-Giro un simple compás y en un círculo yo hago el mundo...<br>
-<br>
-Un pequeño camina y caminando llega al muro<br>
-y luego allí enfrente, esperándonos<br>
-el futuro está...<br>
-<br>
-Y el futuro es una nave espacial que intentamos pilotear.<br>
-No tiene tiempo, ni piedad, ni tiene hora de llegar.<br>
-Sin pedir permiso cambia nuestra vida<br>
-y después nos invita a reír o a llorar.<br>
-<br>
-En esa calle no nos cabe conocer o ver lo que vendrá<br>
-el fin de ella nadie sabe bien cuando será.<br>
-Vamos todos en una linda pasarela de una acuarela<br>
-que un día al fin...<br>
-<br>
-Descolorará...<br>
-<br>
-En una hoja cualquiera yo dibujo un sol amarillo<br>
-<br>
-(Que descolorará!)<br>
-<br>
-Y con cinco o seis rectas es fácil hacer un castillo....<br>
-<br>
-(Que descolorará!)<br>
-<br>
-Giro un simple compás y en un círculo yo hago el mundo...<br>
-<br>
-(Que descolorará!)</div>
+{% poetry() %}
+**Acuarela**
+*Toquinho*
+
+En una hoja cualquiera yo dibujo un sol amarillo
+y con cinco o seis rectas es fácil hacer un castillo
+Corro el lápiz alrededor de la mano y me hago guantes
+y si hago llover tengo un paragüas con dos trazos...
+
+Si una gota de tinta cae en un pedacito azul del papel
+en un instante imagino una linda gaviota dispuesta a volar en el cielo...
+Va volando contorneando la inmensa curva del Norte al Sur.
+Pinto un barco a vela blanco navegando,
+y tanto cielo y mar en un bello azul...
+
+Entre las nubes viene surgiendo un lindo avión rosa y granate
+y todo se vuelve colorido destellando sus luces
+
+Basta imaginar que está partiendo, sereno y lindo...
+si nosotros queremos él va a posar.
+
+En una hoja cualquiera yo dibujo un barco de partida
+con algunos buenos amigos bebiendo bien con la vida...
+
+De una América a otra yo consigo pasar en un segundo
+Giro un simple compás y en un círculo yo hago el mundo...
+
+Un pequeño camina y caminando llega al muro
+y luego allí enfrente, esperándonos
+el futuro está...
+
+Y el futuro es una nave espacial que intentamos pilotear.
+No tiene tiempo, ni piedad, ni tiene hora de llegar.
+Sin pedir permiso cambia nuestra vida
+y después nos invita a reír o a llorar.
+
+En esa calle no nos cabe conocer o ver lo que vendrá
+el fin de ella nadie sabe bien cuando será.
+Vamos todos en una linda pasarela de una acuarela
+que un día al fin...
+
+Descolorará...
+
+En una hoja cualquiera yo dibujo un sol amarillo
+
+(Que descolorará!)
+
+Y con cinco o seis rectas es fácil hacer un castillo....
+
+(Que descolorará!)
+
+Giro un simple compás y en un círculo yo hago el mundo...
+
+(Que descolorará!)
+{% end %}

--- a/content/videos/el-libertador.md
+++ b/content/videos/el-libertador.md
@@ -15,45 +15,47 @@ subtitle = "Ska-P"
 
 {{ video_embed(provider="youtube", id="Du7sbLC9stI") }}
 
-<div class="poetry">Entre miseria, hambre y desolación,<br>
-en el fango alguien plantó una flor<br>
-un tal Bolívar, le dicen el libertador, el libertador<br>
-<br>
-Gritos de justicia, tierra y libertad<br>
-vuelven a resonar en sudamérica<br>
-Ha comenzado una nueva revolución<br>
-y esta vez avanza con convicción<br>
-<br>
-Reforma agraria y justa redistribución,<br>
-sanidad, cultura y buena educación<br>
-Respeto y dignidad al indígena, al indígena<br>
-<br>
-Socializar y ¡no a la privatización!,<br>
-mejoras laborales pa'l trabajador<br>
-Lo que la tierra ofrece es de la población,<br>
-contra la oligarquía y el explotador<br>
-<br>
-Una guerra de medios manipula la verdad<br>
-Enséñale los dientes a la cara al tío sam<br>
-Sin dar un paso atrás.<br>
-<br>
-Adelante comandante, ponte al frente con honestidad<br>
-Comienza a amanecer en latinoamérica<br>
-Paso firme hacia delante, pisa fuerte con rotundidad<br>
-Cuando un pueblo se sabe organizar<br>
-Es un pueblo sabio y libre<br>
-<br>
-Oh oh oh oh! lejos de la perfección<br>
-Se avanza al caminar cuando se tiene ilusión<br>
-<br>
-Una guerra de medios manipula la verdad...<br>
-<br>
-Adelante comandante, ponte al frente con honestidad...<br>
-<br>
-Oh oh oh oh! aires de rebelión en latinoamérica<br>
-Oh oh oh oh! tiempo de transición en toda américa<br>
-<br>
-Adelante comandante, ponte al frente, comandante<br>
-Oh oh oh! de latinoamérica<br>
-Paso firme hacia delante, pisa fuerte, comandante<br>
-Oh oh oh! en latinoamérica.</div>
+{% poetry() %}
+Entre miseria, hambre y desolación,
+en el fango alguien plantó una flor
+un tal Bolívar, le dicen el libertador, el libertador
+
+Gritos de justicia, tierra y libertad
+vuelven a resonar en sudamérica
+Ha comenzado una nueva revolución
+y esta vez avanza con convicción
+
+Reforma agraria y justa redistribución,
+sanidad, cultura y buena educación
+Respeto y dignidad al indígena, al indígena
+
+Socializar y ¡no a la privatización!,
+mejoras laborales pa'l trabajador
+Lo que la tierra ofrece es de la población,
+contra la oligarquía y el explotador
+
+Una guerra de medios manipula la verdad
+Enséñale los dientes a la cara al tío sam
+Sin dar un paso atrás.
+
+Adelante comandante, ponte al frente con honestidad
+Comienza a amanecer en latinoamérica
+Paso firme hacia delante, pisa fuerte con rotundidad
+Cuando un pueblo se sabe organizar
+Es un pueblo sabio y libre
+
+Oh oh oh oh! lejos de la perfección
+Se avanza al caminar cuando se tiene ilusión
+
+Una guerra de medios manipula la verdad...
+
+Adelante comandante, ponte al frente con honestidad...
+
+Oh oh oh oh! aires de rebelión en latinoamérica
+Oh oh oh oh! tiempo de transición en toda américa
+
+Adelante comandante, ponte al frente, comandante
+Oh oh oh! de latinoamérica
+Paso firme hacia delante, pisa fuerte, comandante
+Oh oh oh! en latinoamérica.
+{% end %}

--- a/content/videos/el-umbral.md
+++ b/content/videos/el-umbral.md
@@ -21,23 +21,25 @@ subtitle = "Salen camiones"
 
 **Tabaré Cardozo**
 
-<div class="poetry">Cada uno carga con su alma y con su cruz<br>
-para dar batalla en las tormentas.<br>
-Cada uno carga con las sombras y la luz<br>
-tras de los espejos que se enfrentan.<br>
-<br>
-Y en la brevedad de la eternidad<br>
-cada hombre elige su destino,<br>
-justo en el umbral donde el bien y el mal<br>
-echan a la suerte los caminos<br>
-<br>
-Larairairairara Larairairairara<br>
-Larairairairara Larairairairara<br>
-<br>
-Y en la brevedad, de la eternidad<br>
-cada hombre elige su destino,<br>
-justo en el umbral donde el bien y el mal<br>
-echan a la suerte los caminos</div>
+{% poetry() %}
+Cada uno carga con su alma y con su cruz
+para dar batalla en las tormentas.
+Cada uno carga con las sombras y la luz
+tras de los espejos que se enfrentan.
+
+Y en la brevedad de la eternidad
+cada hombre elige su destino,
+justo en el umbral donde el bien y el mal
+echan a la suerte los caminos
+
+Larairairairara Larairairairara
+Larairairairara Larairairairara
+
+Y en la brevedad, de la eternidad
+cada hombre elige su destino,
+justo en el umbral donde el bien y el mal
+echan a la suerte los caminos
+{% end %}
 
 {% postscript() %}
 Fragmento del programa "Salen Camiones",  diario de viaje de Agarrate Catalina por el Mexico y Cuba durante 2011, emitido por Canal 10 de Montevideo. En este tema: Tabaré Cardozo (letra y guitarra), Emiliano Muñoz (primera voz), Freddy Zurdo Bessio (segunda voz), Maxi Porciuncula y Yamandú Cardozo (coros).

--- a/content/videos/esa-costumbre-de-matar.md
+++ b/content/videos/esa-costumbre-de-matar.md
@@ -14,11 +14,13 @@ tags = [
 video_id = "OJOFeXO2mpE"
 +++
 
-<div class="poetry">*Mi voz la que está gritando<br>
-mi sueño el que sigue entero<br>
-y sepan que sólo muero<br>
-si ustedes van aflojando<br>
-porque el que murió luchando<br>
-vive en cada compañero*</div>
+{% poetry() %}
+*Mi voz la que está gritando
+mi sueño el que sigue entero
+y sepan que sólo muero
+si ustedes van aflojando
+porque el que murió luchando
+vive en cada compañero*
+{% end %}
 
 {{ video_embed(provider="youtube", id="OJOFeXO2mpE") }}

--- a/content/videos/fico-assim-sem-voce.md
+++ b/content/videos/fico-assim-sem-voce.md
@@ -17,57 +17,59 @@ subtitle = "Adriana Calcanhoto"
 
 {{ video_embed(provider="youtube", id="iojYDSjKK00") }}
 
-<div class="poetry">Avião sem asa,<br>
-fogueira sem brasa,<br>
-sou eu assim sem você.<br>
-Futebol sem bola,<br>
-Piu-piu sem Frajola,<br>
-sou eu assim sem você.<br>
-<br>
-Por que é que tem que ser assim<br>
-<br>
-se o meu desejo não tem fim.<br>
-Eu te quero a todo instante<br>
-nem mil auto falantes<br>
-vão poder falar por mim.<br>
-<br>
-Amor sem beijinho,<br>
-Bochecha sem claudinho,<br>
-sou eu assim sem você.<br>
-Circo sem palhaço,<br>
-namoro sem amasó,<br>
-<br>
-sou eu assim sem você<br>
-<br>
-Tô louca pra te ver chegar,<br>
-Tô louca pra te ter nas mãos.<br>
-Deitar no teu abraço,<br>
-Retomar o pedaço que falta no meu coração.<br>
-<br>
-Eu não existo longe de você<br>
-e a solidão é o meu pior castigo.<br>
-<br>
-Eu conto as horas pra poder te ver<br>
-mas o relógio tá de mal comigo<br>
-Por quê?<br>
-Por quê?<br>
-<br>
-Neném sem chupeta,<br>
-Romeu sem Julieta,<br>
-sou eu assim sem você.<br>
-Carro sem estrada,<br>
-queijo sem goiabada,<br>
-sou eu assim sem você<br>
-<br>
-<br>
-Por que é que tem que ser assim<br>
-se o meu desejo não tem fim.<br>
-Eu te quero a todo instante<br>
-nem mil auto falantes vão poder<br>
-falar por mim<br>
-<br>
-Eu não existo longe de você<br>
-e a solidão é o meu pior castigo.<br>
-<br>
-Eu conto as horas pra poder te ver<br>
-mas o relógio tá de mal comigo.</div>
+{% poetry() %}
+Avião sem asa,
+fogueira sem brasa,
+sou eu assim sem você.
+Futebol sem bola,
+Piu-piu sem Frajola,
+sou eu assim sem você.
+
+Por que é que tem que ser assim
+
+se o meu desejo não tem fim.
+Eu te quero a todo instante
+nem mil auto falantes
+vão poder falar por mim.
+
+Amor sem beijinho,
+Bochecha sem claudinho,
+sou eu assim sem você.
+Circo sem palhaço,
+namoro sem amasó,
+
+sou eu assim sem você
+
+Tô louca pra te ver chegar,
+Tô louca pra te ter nas mãos.
+Deitar no teu abraço,
+Retomar o pedaço que falta no meu coração.
+
+Eu não existo longe de você
+e a solidão é o meu pior castigo.
+
+Eu conto as horas pra poder te ver
+mas o relógio tá de mal comigo
+Por quê?
+Por quê?
+
+Neném sem chupeta,
+Romeu sem Julieta,
+sou eu assim sem você.
+Carro sem estrada,
+queijo sem goiabada,
+sou eu assim sem você
+
+
+Por que é que tem que ser assim
+se o meu desejo não tem fim.
+Eu te quero a todo instante
+nem mil auto falantes vão poder
+falar por mim
+
+Eu não existo longe de você
+e a solidão é o meu pior castigo.
+
+Eu conto as horas pra poder te ver
+mas o relógio tá de mal comigo.
+{% end %}

--- a/content/videos/game-called-life.md
+++ b/content/videos/game-called-life.md
@@ -15,63 +15,67 @@ subtitle = "Leftover Cuties"
 
 {{ video_embed(provider="youtube", id="ZDHofTEYeoQ") }}
 
-<div class="poetry">It's so hard to turn your life over<br>
-Step out of your comfort zone<br>
-It's so hard to choose one direction<br>
-When your future is unknown<br>
-<br>
-Is this some kind of a joke, will someone wake me up soon?<br>
-And tell me this was just a game we played, called life.<br>
-<br>
-Are we, are we all really slaves?<br>
-By the hands of ourselves<br>
-Did I really make all of those mistakes?<br>
-Am I really getting older?<br>
-Then why do I feel so lost?<br>
-<br>
-Is this some kind of a joke, will someone wake me up soon?<br>
-And tell me this was just a game we played, called life.<br>
-<br>
-And at the end of the road, is there someone waiting?<br>
-Do I get a medal for surviving this long?<br>
-<br>
-Is this some kind of a joke, will someone wake me up soon?<br>
-And tell me this was just a game we played, called life.<br>
-<br>
-Is this some kind of a joke, will someone wake me up soon?<br>
-And tell me this was just a game we played, called life.</div>
+{% poetry() %}
+It's so hard to turn your life over
+Step out of your comfort zone
+It's so hard to choose one direction
+When your future is unknown
+
+Is this some kind of a joke, will someone wake me up soon?
+And tell me this was just a game we played, called life.
+
+Are we, are we all really slaves?
+By the hands of ourselves
+Did I really make all of those mistakes?
+Am I really getting older?
+Then why do I feel so lost?
+
+Is this some kind of a joke, will someone wake me up soon?
+And tell me this was just a game we played, called life.
+
+And at the end of the road, is there someone waiting?
+Do I get a medal for surviving this long?
+
+Is this some kind of a joke, will someone wake me up soon?
+And tell me this was just a game we played, called life.
+
+Is this some kind of a joke, will someone wake me up soon?
+And tell me this was just a game we played, called life.
+{% end %}
 
 Mi humilde traducción
 
 ### Un juego llamado vida
 
-<div class="poetry">Es tan duro dar vuelta está página de tu vida<br>
-dar el paso fuera de tu zona de confort<br>
-Es tan duro elegir una dirección<br>
-cuando tu futuro es desconocido<br>
-<br>
-¿Es una especie de broma?<br>
-¿Alguien me despertará pronto<br>
-y me dirá que es es sólo un juego<br>
-llamado vida ?<br>
-<br>
-¿Realmente somos<br>
-todos nosotros esclavos?<br>
-¿ Cometí todos esos errores con mis propias manos?<br>
-¿ De verdad me estoy haciendo más grande?<br>
-¿ Entonces por qué me siento tan perdido?<br>
-<br>
-¿Es una especie de broma?<br>
-¿Alguien me despertará pronto<br>
-y me dirá que es es sólo un juego<br>
-llamado vida ?<br>
-<br>
-¿Y al final del camino,<br>
-hay alguien esperando?<br>
-¿Conseguiré una medalla<br>
-por sobrevivir a tanto ?<br>
-<br>
-¿Es una especie de broma?<br>
-¿Alguien me despertará pronto<br>
-y me dirá que es es sólo un juego<br>
-llamado vida ?</div>
+{% poetry() %}
+Es tan duro dar vuelta está página de tu vida
+dar el paso fuera de tu zona de confort
+Es tan duro elegir una dirección
+cuando tu futuro es desconocido
+
+¿Es una especie de broma?
+¿Alguien me despertará pronto
+y me dirá que es es sólo un juego
+llamado vida ?
+
+¿Realmente somos
+todos nosotros esclavos?
+¿ Cometí todos esos errores con mis propias manos?
+¿ De verdad me estoy haciendo más grande?
+¿ Entonces por qué me siento tan perdido?
+
+¿Es una especie de broma?
+¿Alguien me despertará pronto
+y me dirá que es es sólo un juego
+llamado vida ?
+
+¿Y al final del camino,
+hay alguien esperando?
+¿Conseguiré una medalla
+por sobrevivir a tanto ?
+
+¿Es una especie de broma?
+¿Alguien me despertará pronto
+y me dirá que es es sólo un juego
+llamado vida ?
+{% end %}

--- a/content/videos/hey-you-pink-floyd.md
+++ b/content/videos/hey-you-pink-floyd.md
@@ -14,42 +14,44 @@ video_id = "lRcQZ2tnWeg"
 
 {{ video_embed(provider="youtube", id="lRcQZ2tnWeg") }}
 
-<div class="poetry">Hey tu,<br>
-Allí afuera en el frío,<br>
-Quedándote solo, haciéndote viejo,<br>
-¿Puedes sentirme?<br>
-Hey tu,<br>
-Parado en el pasillo<br>
-Con la picazón en tu pie y una sonrisa que se desvanece<br>
-¿Puedes sentirme?<br>
-Hey tu,<br>
-No les ayudes a enterrar la luz.<br>
-No te des por vencido sin luchar.<br>
-<br>
-Hey tu,<br>
-Allí afuera solo,<br>
-Sentado desnudo en el teléfono<br>
-¿Me tocarías?<br>
-Hey tu,<br>
-Con tu oído contra la pared,<br>
-Esperando a alguien a quien llamar<br>
-¿Me tocarías?<br>
-Hey tu,<br>
-¿Me ayudarías a cargar la piedra?<br>
-Abre tu corazón, estoy llegando a casa.<br>
-Pero era solo una fantasía.<br>
-La pared era demasiado alta, como puedes ver.<br>
-No importa cómo él intentó, no podría romperse libremente.<br>
-Y los gusanos se comieron su cerebro.<br>
-<br>
-Hey tu,<br>
-Allí afuera en el camino,<br>
-Haciendo siempre lo que te dicen,<br>
-¿Puedes ayudarme?<br>
-Hey tu,<br>
-Allí afuera más allá de la pared,<br>
-Rompiendo botellas en el pasillo,<br>
-¿Puedes ayudarme?<br>
-Hey tu,<br>
-No me digas que no hay nada de esperanzas.<br>
-Juntos estamos parados, divididos nos caemos</div>
+{% poetry() %}
+Hey tu,
+Allí afuera en el frío,
+Quedándote solo, haciéndote viejo,
+¿Puedes sentirme?
+Hey tu,
+Parado en el pasillo
+Con la picazón en tu pie y una sonrisa que se desvanece
+¿Puedes sentirme?
+Hey tu,
+No les ayudes a enterrar la luz.
+No te des por vencido sin luchar.
+
+Hey tu,
+Allí afuera solo,
+Sentado desnudo en el teléfono
+¿Me tocarías?
+Hey tu,
+Con tu oído contra la pared,
+Esperando a alguien a quien llamar
+¿Me tocarías?
+Hey tu,
+¿Me ayudarías a cargar la piedra?
+Abre tu corazón, estoy llegando a casa.
+Pero era solo una fantasía.
+La pared era demasiado alta, como puedes ver.
+No importa cómo él intentó, no podría romperse libremente.
+Y los gusanos se comieron su cerebro.
+
+Hey tu,
+Allí afuera en el camino,
+Haciendo siempre lo que te dicen,
+¿Puedes ayudarme?
+Hey tu,
+Allí afuera más allá de la pared,
+Rompiendo botellas en el pasillo,
+¿Puedes ayudarme?
+Hey tu,
+No me digas que no hay nada de esperanzas.
+Juntos estamos parados, divididos nos caemos
+{% end %}

--- a/content/videos/mamita-peyote.md
+++ b/content/videos/mamita-peyote.md
@@ -15,46 +15,46 @@ video_id = "wAVUYDCjov8"
 
 {{ video_embed(provider="youtube", id="wAVUYDCjov8", title="Mamita Peyote - Sentencia") }}
 
-<div class="poetry">
-En un bosque de mentiras estamos perdidos sin poder escapar.<br>
-Y si el camino está lleno de lobos, habrá que aprender a cazar.<br>
-<br>
-Encadenado a tu codicia sos brillante en ocultar.<br>
-Tené cuidado con lo que me escondas:<br>
-hay un destape a punto de estallar.<br>
-<br>
-Hasta en las más viejas ruinas<br>
-tienen escrita la palabra poder.<br>
-Todo vuelve en la vida, este sol vio imperios caer.<br>
-<br>
-<em>Estribillo:</em><br>
-<br>
-Habrá consecuencias, ante tantas faltas y engaños,<br>
-ante tanto mal provocado.<br>
-Ante tan deliberada crueldad, amor.<br>
-<br>
-Habrá consecuencias.<br>
-Porque no se miente de esa manera.<br>
-Lo que nace en el odio en el odio se queda.<br>
-Voy a rogar que una fuerza sobrenatural<br>
-sentencie tu esencia.<br>
-<br>
----<br>
-<br>
-En un desierto de ánimas negras pretendes enterrarme para no verme más.<br>
-Lo que se entierra crece, se hace más fuerte<br>
-y te puede venir a buscar.<br>
-<br>
-Encadenado a tu codicia sos brillante en ocultar.<br>
-Tené cuidado con lo que me escondas,<br>
-hay un destape a punto de estallar.<br>
-<br>
-Hasta en las más viejas ruinas<br>
-tienen escrita la palabra poder.<br>
-Todo vuelve en la vida, este sol vio imperios caer.<br>
-<br>
-<em>Estribillo bis.</em>
-</div>
+{% poetry() %}
+En un bosque de mentiras estamos perdidos sin poder escapar.
+Y si el camino está lleno de lobos, habrá que aprender a cazar.
+
+Encadenado a tu codicia sos brillante en ocultar.
+Tené cuidado con lo que me escondas:
+hay un destape a punto de estallar.
+
+Hasta en las más viejas ruinas
+tienen escrita la palabra poder.
+Todo vuelve en la vida, este sol vio imperios caer.
+
+*Estribillo:*
+
+Habrá consecuencias, ante tantas faltas y engaños,
+ante tanto mal provocado.
+Ante tan deliberada crueldad, amor.
+
+Habrá consecuencias.
+Porque no se miente de esa manera.
+Lo que nace en el odio en el odio se queda.
+Voy a rogar que una fuerza sobrenatural
+sentencie tu esencia.
+
+---
+
+En un desierto de ánimas negras pretendes enterrarme para no verme más.
+Lo que se entierra crece, se hace más fuerte
+y te puede venir a buscar.
+
+Encadenado a tu codicia sos brillante en ocultar.
+Tené cuidado con lo que me escondas,
+hay un destape a punto de estallar.
+
+Hasta en las más viejas ruinas
+tienen escrita la palabra poder.
+Todo vuelve en la vida, este sol vio imperios caer.
+
+*Estribillo bis.*
+{% end %}
 
 {% postscript() %}
 Músicos Invitados: Daniel Suárez y Cóndor Sbarbati (de Bersuit Vergarabat), Mariano Franceschelli y Martin "Moska" Lorenzo (de Los Auténticos Decadentes) en batería y percusión.

--- a/templates/shortcodes/poetry.html
+++ b/templates/shortcodes/poetry.html
@@ -1,2 +1,3 @@
-<div class="poetry">{{ body | trim | markdown | replace(from="
-", to="<br>") | safe }}</div>
+<div class="poetry">{{ body | trim | replace(from="
+", to="<br>
+") | markdown | safe }}</div>


### PR DESCRIPTION
Closes #258.

## Cambios
- Migra bloques HTML `<div class="poetry">` del cuerpo de artículos al shortcode `{% poetry() %}`.
- Ajusta el shortcode para que el contenido fuente use saltos normales y el HTML final tenga un único `<br>` por salto.

## Verificación
- `PATH=/tmp/zola-0.22.1:$PATH npm run build`

Nota: usé Zola 0.22.1 descargado en `/tmp` porque el `zola` local en `$PATH` es un binario ARM y esta máquina es x86_64.
