### PR TITLE
Crear post de video Qatar en contexto

### DIFF
--- a/content/autores/octavio-gencarelli.md
+++ b/content/autores/octavio-gencarelli.md
@@ -1,0 +1,7 @@
++++
+title = "Octavio Gencarelli"
+template = "author.html"
+
+[extra]
+image = ""
++++

--- a/content/etiquetas/qatar.md
+++ b/content/etiquetas/qatar.md
@@ -1,0 +1,8 @@
++++
+title = "Qatar"
+template = "tag.html"
+
+[extra]
+group_id = 99
+group_name = "transversales"
++++

--- a/content/videos/qatar-en-contexto.md
+++ b/content/videos/qatar-en-contexto.md
@@ -1,0 +1,46 @@
++++
+title = "Qatar en contexto"
+slug = "qatar-en-contexto"
+date = 2026-06-10 22:58:00
+description = "La serie completa de videos de Octavio Gencarelli sobre el recorrido de Argentina en Qatar."
+authors = [
+    "Octavio Gencarelli",
+]
+tags = [
+    "La pelota no se mancha",
+    "Deporte",
+    "Qatar",
+]
+
+[extra]
+hero_image = "https://drive.google.com/thumbnail?id=1zCHZhGzDn0y2waTvnX9NaN60HrEzmo1-&sz=w1200"
+hero_alt = "Qatar en contexto, capítulo 1: Argentina vs Arabia Saudita"
++++
+
+## CAP 1 | Argentina vs Arabia Saudita | Los hijos de Gardel.
+
+{{ video_embed(provider="googledrive", id="1zCHZhGzDn0y2waTvnX9NaN60HrEzmo1-", title="CAP 1 | Argentina vs Arabia Saudita | Los hijos de Gardel.") }}
+
+## CAP 2 | Argentina vs México | Las habladurías del mundo.
+
+{{ video_embed(provider="googledrive", id="18lLeQCStsuQiMWntCOM-_nirtwmKHLHO", title="CAP 2 | Argentina vs México | Las habladurías del mundo.") }}
+
+## CAP 3 | Argentina vs Polonia | Vine hasta aquí
+
+{{ video_embed(provider="googledrive", id="1_9NcBdQULHG0Eaw4emkt9f62beJDe5Ts", title="CAP 3 | Argentina vs Polonia | Vine hasta aquí") }}
+
+## CAP 4 | Argentina vs Australia | Investido
+
+{{ video_embed(provider="googledrive", id="1cEjOS6_xod-sjqFgVjHKJQ_PqFbimXNq", title="CAP 4 | Argentina vs Australia | Investido") }}
+
+## CAP 5 | Argentina vs Países Bajos | Cinema Verité
+
+{{ video_embed(provider="googledrive", id="1epuhb3bbXNre7VlHVxC5B02k_HwbD85p", title="CAP 5 | Argentina vs Países Bajos | Cinema Verité") }}
+
+## CAP 6 | Argentina vs Croacia | Duo de amor
+
+{{ video_embed(provider="googledrive", id="1tk7cPo9UBX2jT2dtJuPu8Y5t0ckr2SzC", title="CAP 6 | Argentina vs Croacia | Duo de amor") }}
+
+## CAP 7 | Argentina vs Francia | Un poco de amor francés
+
+{{ video_embed(provider="googledrive", id="1iGg3X1MJje7I_zNej6elUXzYqVbx5iw8", title="CAP 7 | Argentina vs Francia | Un poco de amor francés") }}

--- a/data/site_index.json
+++ b/data/site_index.json
@@ -1073,6 +1073,18 @@
       "title": "Nicolás Guillén",
       "url": "/autores/nicolas-guillen/"
     },
+    "Octavio Gencarelli": {
+      "articles": [
+        "videos/qatar-en-contexto.md"
+      ],
+      "gender": "m",
+      "group_name": "",
+      "image": "",
+      "is_owner": false,
+      "slug": "octavio-gencarelli",
+      "title": "Octavio Gencarelli",
+      "url": "/autores/octavio-gencarelli/"
+    },
     "Oliverio Girondo": {
       "articles": [
         "de-otros/el-puro-no.md",
@@ -15700,9 +15712,9 @@
       ],
       "comment_count": 0,
       "date": "2026-05-23 00:00:00",
-      "description": "Discurso leído el 23 de mayo de 2006 en el festejo de nuestro <a href=\"https://locrasorio.pages.dev/\">Locrasorio</a>",
+      "description": "Discurso leído el 23 de mayo de 2026 en el festejo de nuestro Locrasorio",
       "hero_alt": "",
-      "hero_image": "",
+      "hero_image": "https://locrasorio.pages.dev/images/gallery/gallery-14.jpg",
       "section_slug": "blog",
       "section_title": "Blog",
       "tags": [],
@@ -20161,6 +20173,26 @@
       "title": "Presto",
       "url": "/videos/presto/",
       "video_id": "qp71kQZMRZM"
+    },
+    "videos/qatar-en-contexto.md": {
+      "authors": [
+        "Octavio Gencarelli"
+      ],
+      "comment_count": 0,
+      "date": "2026-06-10 22:58:00",
+      "description": "La serie completa de videos de Octavio Gencarelli sobre el recorrido de Argentina en Qatar.",
+      "hero_alt": "Qatar en contexto, capítulo 1: Argentina vs Arabia Saudita",
+      "hero_image": "https://drive.google.com/thumbnail?id=1zCHZhGzDn0y2waTvnX9NaN60HrEzmo1-&sz=w1200",
+      "section_slug": "videos",
+      "section_title": "Videos",
+      "tags": [
+        "La pelota no se mancha",
+        "Deporte",
+        "Qatar"
+      ],
+      "title": "Qatar en contexto",
+      "url": "/videos/qatar-en-contexto/",
+      "video_id": ""
     },
     "videos/rafael-correa-gana-reeleccion.md": {
       "authors": [
@@ -31612,6 +31644,7 @@
     },
     "Deporte": {
       "articles": [
+        "videos/qatar-en-contexto.md",
         "blog/fideo.md"
       ],
       "gender": "m",
@@ -31851,6 +31884,7 @@
     },
     "La pelota no se mancha": {
       "articles": [
+        "videos/qatar-en-contexto.md",
         "blog/fideo.md"
       ],
       "gender": "m",
@@ -32061,6 +32095,18 @@
       "slug": "politica",
       "title": "Política",
       "url": "/etiquetas/politica/"
+    },
+    "Qatar": {
+      "articles": [
+        "videos/qatar-en-contexto.md"
+      ],
+      "gender": "m",
+      "group_name": "transversales",
+      "image": "",
+      "is_owner": false,
+      "slug": "qatar",
+      "title": "Qatar",
+      "url": "/etiquetas/qatar/"
     },
     "Refrito de Verano": {
       "articles": [

--- a/scripts/spell_allow.txt
+++ b/scripts/spell_allow.txt
@@ -5711,3 +5711,14 @@ america
 américa
 adelántame
 desandó
+
+# --- Tanda 2026-06-10 ---
+Arabia
+Cinema
+Duo
+Gardel
+Gencarelli
+Investido
+Qatar
+Saudita
+Verité

--- a/templates/shortcodes/video_embed.html
+++ b/templates/shortcodes/video_embed.html
@@ -21,6 +21,14 @@
         loading="lazy"
         allowfullscreen
       ></iframe>
+    {% elif provider == "googledrive" %}
+      <iframe
+        src="https://drive.google.com/file/d/{{ id }}/preview"
+        title="{{ title | default(value="Video") }}"
+        loading="lazy"
+        allow="autoplay; fullscreen"
+        allowfullscreen
+      ></iframe>
     {% endif %}
   </div>
 </figure>


### PR DESCRIPTION
## Resumen

- Crea el post publicado `Qatar en contexto` en `videos`, con autor Octavio Gencarelli.
- Embebe los 7 videos públicos de la carpeta Drive mediante soporte `googledrive` en el shortcode `video_embed`.
- Usa la miniatura pública del primer video como portada y agrega autor/etiqueta mínimos.

Closes #279

## Pruebas

- `npm run build`
- `git diff --check`

## Nota

- `uv run scripts/check_spelling.py content/videos/qatar-en-contexto.md content/autores/octavio-gencarelli.md content/etiquetas/qatar.md` no pudo correr porque falta `hunspell` en el PATH local; agregué allow-list preventiva para términos nuevos.
